### PR TITLE
bot: Remova o exercício wall squat da série D de academia. O usuário não qu

### DIFF
--- a/.claude/agent-memory/fisioterapeuta-preventivo/project_joelho_esquerdo.md
+++ b/.claude/agent-memory/fisioterapeuta-preventivo/project_joelho_esquerdo.md
@@ -36,7 +36,8 @@ metadata:
 - Ativação VMO: isométrico em 30° com rotação externa do pé, hold 5s, 2×15 (aquecimento B e D) — REVISADO de bola entre joelhos
 - Clamshell: 2×15/lado (aquecimento B e D)
 - Dorsiflexão no step: 2×10/perna (aquecimento B e D)
-- Wall squat excêntrico: 3×8 a 8–10s (finalização B e D)
+- Wall squat excêntrico: 3×8 a 8–10s (finalização B apenas — removido de D em 18/05/2026)
+- Cadeira extensora isométrica terminal (20°→0°): 3×10, hold 3s, cadência 2-3-3, RPE 4 — SUBSTITUIU wall squat no Treino D (18/05/2026)
 
 ### TKE — execução refinada para VMO
 - Pé em rotação externa 15–20°, hold 2s em extensão máxima com feedback tátil (mão no VMO)

--- a/.claude/agent-memory/personal-trainer-reviewer/MEMORY.md
+++ b/.claude/agent-memory/personal-trainer-reviewer/MEMORY.md
@@ -5,3 +5,4 @@
 
 ## Série e Estado do Programa
 - [project_serie_estado_atual.md](project_serie_estado_atual.md) — Snapshot da série vigente (Abr/2026): divisão A/B/C/D, volumes, mudanças de 02/04/2026, alertas ativos e pendências identificadas
+- [project_joelho_wall_squat.md](project_joelho_wall_squat.md) — Wall squat removido do Treino D em 18/05/2026 (mantido no B); substituto aprovado: isométrico leg press 30-40° 2×5×10s

--- a/.claude/agent-memory/personal-trainer-reviewer/project_joelho_wall_squat.md
+++ b/.claude/agent-memory/personal-trainer-reviewer/project_joelho_wall_squat.md
@@ -1,0 +1,42 @@
+---
+name: wall-squat-treino-d-remocao
+description: Decisão de remover wall squat excêntrico do Treino D (mantido no B) e substituto aprovado — 18/05/2026
+metadata:
+  type: project
+---
+
+## Decisão (18/05/2026)
+
+Wall squat excêntrico removido do Treino D (Lower B, Quinta). Mantido no Treino B (Lower A, Terça).
+
+**Why:** Patrick nao quer fazer wall squat no Treino D. Tecnicamente aprovado porque: (1) redundância adequada — exercício permanece no B; (2) no Treino D o wall squat era o 9° exercício, após fadiga acumulada de leg press isométrico + leg press dinâmico + 5 séries de mesa flexora, aumentando risco de compensação sobre tendao lesionado; (3) o leg press D3 com cadência 4-1-3 já provê controle excêntrico em aparelho.
+
+**How to apply:** Ao revisar Treino D futuramente, nao incluir wall squat. O wall squat só deve aparecer no Treino B.
+
+## Criterio de Progressao da Fase 2
+
+O criterio original era: "dor 0-1/10 no leg press restrito por 2 treinos seguidos + wall squat 3×8 sem dor → liberar amplitude/carga progressiva no leg press"
+
+Com a remocao do D, o criterio de wall squat é avaliado APENAS no Treino B. Isso é funcionalmente válido — o criterio nao exige avaliacao em ambos os treinos.
+
+## Substituto Aprovado no Treino D
+
+**Opcao primária (sem necessidade de novo equipamento):**
+- Isométrico de Leg Press 45° em 30-40° de flexao de joelho
+- 2 × 5 holds de 8-10s
+- Carga: mesma do D3 ou -10%
+- Descanso entre holds: 30s
+- Posicao diferente do D2 (que usa 45-60°) — menor compressao patelofemoral, estimulo de VMO em extensao proximal
+
+**Opcao alternativa (se hack squat máquina disponível):**
+- Hack squat máquina, amplitude restrita 60-70°
+- 3 × 8, cadência 4-1-2
+- Carga: -30% vs leg press amplitude completa, RPE 5-6
+- VERIFICAR disponibilidade antes de incluir — nao consta nos equipamentos documentados
+
+## Impacto no Volume
+
+| Grupo | Antes | Depois |
+|---|---|---|
+| Wall squat semanal | 6 sets (B+D) | 3 sets (apenas B) |
+| Volume D quad | 6 sets + 3 wall squat | 6 sets + 2-3 isométrico leg press diferido |

--- a/serie-academia.md
+++ b/serie-academia.md
@@ -133,7 +133,7 @@ title: Série de Musculação
 | 6 | **Cadeira adutora** [📸](https://cdn.muscleandstrength.com/sites/default/files/hip-adduction-machine.jpg) | 3 × 15 | Adutores do quadril — par com a abdutora; estabilidade pélvica e prevenção de lesão de virilha. RPE 6. |
 | 7 | **Panturrilha em pé** (máquina) [📸](https://www.mundoboaforma.com.br/wp-content/uploads/2022/10/aparelho-panturrilha.jpg) | 3 × 12–15 | Amplitude completa; frequência 2×/semana. |
 | 8 | **Rollout no trilho reto inclinado** [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2017/09/abdominal-maquina.gif) | 3 × 8–10 | Apoio no cotovelo; ajoelhado no carrinho; cadência 3-1-2; iniciar com ~60% do trilho, progredir amplitude progressivamente. **Queixo levemente recolhido — cervical neutra durante todo o movimento**. |
-| 9 | **Wall squat excêntrico** | 3 × 8 (excêntrica de 8–10s) | 🦵 **Adicionado 14/05.** Descida lenta encostado na parede até ~60° de flexão; sem dor. Reforço de quadríceps em carga controlada. |
+| 9 | **Cadeira extensora — isométrico terminal** | 3 × 10 (hold 3s em extensão máxima) | 🦵 **Substituiu wall squat excêntrico em 18/05.** Amplitude restrita a **20°→0° apenas** — não descer além de 20° de flexão. Pé em rotação externa 15–20°; mão no VMO para feedback tátil; hold 3s em extensão máxima; cadência 2-3-3; carga LEVE (RPE 4). Objetivo: recrutar VMO em arco sem estresse de tração na inserção tendínea. Wall squat mantido apenas no Treino B. |
 | 10 | **Máquina de rotação de tronco** (torso rotation machine) [📸](https://totalpass.com/wp-content/uploads/2025/12/twist1.png) | 2 × 12 (cada lado) | ⚠️ Substitui Cable Chop/Lift (causou dor no ombro). Carga LEVE; antebraços nos suportes (mãos sem preensão ativa); movimento pelo tronco — não pelos ombros; tempo 3-1-2 (3s retorno); **olhar fixo à frente** — cervical NÃO rotaciona junto. |
 
 **Pós-treino (~4 min):**
@@ -141,7 +141,7 @@ title: Série de Musculação
 - **Mobilização patelar passiva**: 1 min
 - **Gelo no polo superior da patela esquerda**: 10–12 min
 
-**Volume D:** 30 sets — Glúteo máximo: 4 · Quadríceps: 6 (Isométrico 3 + Leg press 3) · Wall squat excêntrico: 3 · Isquiotibiais: 5 · Glúteo médio: 3 · Adutores: 3 · Panturrilha: 3 · Core: 5
+**Volume D:** 30 sets — Glúteo máximo: 4 · Quadríceps: 9 (Isométrico leg press 3 + Leg press 3 + Extensora terminal 3) · Isquiotibiais: 5 · Glúteo médio: 3 · Adutores: 3 · Panturrilha: 3 · Core: 5
 
 ---
 
@@ -156,8 +156,8 @@ title: Série de Musculação
 | **Tríceps** | 5 | — | 3 | — | **8** |
 | **Bíceps** | 6 | — | 8 | — | **14** |
 | **Glúteo máximo** | — | — | — | 4 | **4** |
-| **Quadríceps** | — | 6 | — | 6 | **12** (🦵 reduzido temporariamente 14/05; era 13) |
-| **Wall squat excêntrico** | — | 3 | — | 3 | **6** (🦵 adicionado 14/05) |
+| **Quadríceps** | — | 6 | — | 9 | **15** (🦵 D ajustado 18/05: extensora terminal substituiu wall squat) |
+| **Wall squat excêntrico** | — | 3 | — | — | **3** (🦵 removido do D em 18/05; mantido no B) |
 | **Isquiotibiais** | — | 4 | — | 5 | **9** (🦵 aumentado 14/05; era 7) |
 | **Panturrilha** | — | 3 | — | 3 | **6** |
 | **Glúteo médio** | — | 3 | — | 3 | **6** |
@@ -232,7 +232,7 @@ Vasto lateral encurtado/dominante (resultado do retorno ao ciclismo) traciona a 
 - Cadeira extensora **→ Isométrico de leg press em 45–60°** no Treino D
 - Leg press 45°: ROM 60–70°, carga −20–25%, pés em rotação externa 15–20°, terço médio-superior da plataforma
 - Aquecimento: foam roll TFL + vasto lateral (5 min), ativação VMO em 30° com rotação externa, clamshell, dorsiflexão no step
-- Adicionado wall squat excêntrico (3×8 com excêntrica de 8–10s) ao final de B e D
+- Wall squat excêntrico (3×8 com excêntrica de 8–10s): mantido ao final de B; removido de D em 18/05 — substituído por cadeira extensora isométrica terminal (20°→0°, 3×10, hold 3s, RPE 4)
 - Pós-treino: alongamento Ober + mobilização patelar passiva + gelo 10–12 min
 
 ### Critérios de progressão


### PR DESCRIPTION
### Pedido (Telegram)
Remova o exercício wall squat da série D de academia. O usuário não quer fazer esse exercício. Por favor, verifique com os agentes especialistas em treino se existe algum outro exercício em aparelho que seja um bom substituto para o wall squat, considerando os mesmos grupos musculares e objetivos.

### Resumo da mudança
Wall squat excêntrico removido do Treino D e substituído por cadeira extensora em arco terminal isométrico (20°→0°, 3×10, hold 3s, RPE 4, carga leve). Wall squat mantido no Treino B; critério de progressão da Fase 2 do protocolo do joelho preservado.

### Arquivos editados
- `serie-academia.md`

### Pareceres dos agents
- **personal-trainer-reviewer** → `approved`: Aprovado. Wall squat no Treino D era redundante e estava posicionado após fadiga acumulada de quadríceps (9° exercício). 3 sets/semana no Treino B são suficientes para estímulo terapêutico tendíneo. Substituto (cadeira extensora isométrico terminal 20°→0°) aprovado com especificações: 3×10, hold 3s em extensão máxima, cadência 2-3-3, carga leve RPE 4, pé em rotação externa 15–20°, mão no VMO para biofeedback.
- **fisioterapeuta-preventivo** → `approved`: Aprovado clinicamente. Redução de 6 para 3 sets/semana de wall squat é segura — 3 sets em B são suficientes para estímulo tendíneo na fase reativa. Critério de progressão (wall squat 3×8 sem dor) continua avaliável pelo Treino B. Substituto (cadeira extensora em arco terminal 20°→0° isométrico) apresenta função terapêutica superior no contexto do Treino D: recruta VMO no ângulo de maior vantagem mecânica, com menor tensão na inserção do tendão quadricipital lateral.

---
_Gerado pelo bot-worker do CriaPix. Task id: `53457306c5fe`._