### PR TITLE
bot: Remove todas as atividades de pós-treino (alongamento, mobilização, ge

### DIFF
--- a/.claude/agent-memory/personal-trainer-reviewer/MEMORY.md
+++ b/.claude/agent-memory/personal-trainer-reviewer/MEMORY.md
@@ -6,3 +6,4 @@
 ## Série e Estado do Programa
 - [project_serie_estado_atual.md](project_serie_estado_atual.md) — Snapshot da série vigente (Abr/2026): divisão A/B/C/D, volumes, mudanças de 02/04/2026, alertas ativos e pendências identificadas
 - [project_joelho_wall_squat.md](project_joelho_wall_squat.md) — Wall squat removido do Treino D em 18/05/2026 (mantido no B); substituto aprovado: isométrico leg press 30-40° 2×5×10s
+- [project_joelho_pos_treino_remocao.md](project_joelho_pos_treino_remocao.md) — Bloco pós-treino terapêutico (gelo + mobilização patelar + Ober) removido dos Treinos B e D em 18/05/2026; aprovado pois são procedimentos clínicos, não de treinamento

--- a/.claude/agent-memory/personal-trainer-reviewer/project_joelho_pos_treino_remocao.md
+++ b/.claude/agent-memory/personal-trainer-reviewer/project_joelho_pos_treino_remocao.md
@@ -1,0 +1,24 @@
+---
+name: joelho-pos-treino-remocao
+description: Remoção do bloco pós-treino terapêutico (gelo + mobilização patelar + alongamento Ober) dos Treinos B e D em 18/05/2026
+metadata:
+  type: project
+---
+
+## Decisão (18/05/2026)
+
+Bloco pós-treino removido dos Treinos B (Lower A, Terça) e D (Lower B, Quinta), a pedido do usuário.
+
+**Conteúdo removido (idêntico em ambos os treinos):**
+- Alongamento Ober (TFL/IT band): 2×30s/lado
+- Mobilização patelar passiva: 1 min
+- Gelo no polo superior da patela esquerda: 10–12 min
+- Duração total: ~4 min (mais 10-12 min de gelo)
+
+A referência ao protocolo também foi removida da seção "Protocolo do Joelho Esquerdo (Adaptações ativas)".
+
+**Why:** Patrick pediu a remoção. Tecnicamente aprovado pelo personal trainer porque esses procedimentos são terapêuticos/recuperativos, não componentes de treinamento — sua ausência não afeta volume, intensidade, progressão ou estrutura da sessão.
+
+**How to apply:** Não reinstaurar o bloco pós-treino automaticamente em futuras revisões. Qualquer rereinserção de gelo/mobilização patelar é decisão clínica (fisioterapeuta), não de programação de treino. O protocolo de aquecimento completo (~13 min) permanece intacto em ambos os treinos.
+
+**Contexto clínico:** Patrick tem hipótese de entesopatia do tendão quadricipital lateral no joelho esquerdo (levantada em 14/05/2026). O protocolo de aquecimento (foam roll TFL + vasto lateral, ativação VMO, clamshell, dorsiflexão) permanece ativo.

--- a/serie-academia.md
+++ b/serie-academia.md
@@ -72,11 +72,6 @@ title: Série de Musculação
 | 7 | **Wall squat excêntrico** | 3 × 8 (excêntrica de 8–10s) | 🦵 **Adicionado 14/05.** Descida lenta encostado na parede até ~60° de flexão; sem dor. Finalização do treino para reforço de quadríceps em carga controlada. |
 | 8 | **Rollout no trilho em C** [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2017/09/abdominal-maquina.gif) | 3 × 8–10 | Apoio no cotovelo; ajoelhado no carrinho; cadência 3-1-2; amplitude ~60–80% do trilho. **Queixo levemente recolhido — cervical neutra durante todo o movimento**; parar a saída antes de qualquer extensão cervical. |
 
-**Pós-treino (~4 min):**
-- **Alongamento Ober** (TFL/IT band): 2×30s/lado
-- **Mobilização patelar passiva**: 1 min
-- **Gelo no polo superior da patela esquerda**: 10–12 min
-
 **Volume B:** 22 sets — Quadríceps: 6 (TKE 3 + Leg press 3) · Wall squat excêntrico: 3 · Isquiotibiais: 4 · Glúteo médio: 3 · Adutores: 3 · Panturrilha: 3 · Core: 3
 
 ---
@@ -135,11 +130,6 @@ title: Série de Musculação
 | 8 | **Rollout no trilho reto inclinado** [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2017/09/abdominal-maquina.gif) | 3 × 8–10 | Apoio no cotovelo; ajoelhado no carrinho; cadência 3-1-2; iniciar com ~60% do trilho, progredir amplitude progressivamente. **Queixo levemente recolhido — cervical neutra durante todo o movimento**. |
 | 9 | **Cadeira extensora — isométrico terminal** | 3 × 10 (hold 3s em extensão máxima) | 🦵 **Substituiu wall squat excêntrico em 18/05.** Amplitude restrita a **20°→0° apenas** — não descer além de 20° de flexão. Pé em rotação externa 15–20°; mão no VMO para feedback tátil; hold 3s em extensão máxima; cadência 2-3-3; carga LEVE (RPE 4). Objetivo: recrutar VMO em arco sem estresse de tração na inserção tendínea. Wall squat mantido apenas no Treino B. |
 | 10 | **Máquina de rotação de tronco** (torso rotation machine) [📸](https://totalpass.com/wp-content/uploads/2025/12/twist1.png) | 2 × 12 (cada lado) | ⚠️ Substitui Cable Chop/Lift (causou dor no ombro). Carga LEVE; antebraços nos suportes (mãos sem preensão ativa); movimento pelo tronco — não pelos ombros; tempo 3-1-2 (3s retorno); **olhar fixo à frente** — cervical NÃO rotaciona junto. |
-
-**Pós-treino (~4 min):**
-- **Alongamento Ober** (TFL/IT band): 2×30s/lado
-- **Mobilização patelar passiva**: 1 min
-- **Gelo no polo superior da patela esquerda**: 10–12 min
 
 **Volume D:** 30 sets — Glúteo máximo: 4 · Quadríceps: 9 (Isométrico leg press 3 + Leg press 3 + Extensora terminal 3) · Isquiotibiais: 5 · Glúteo médio: 3 · Adutores: 3 · Panturrilha: 3 · Core: 5
 
@@ -233,7 +223,6 @@ Vasto lateral encurtado/dominante (resultado do retorno ao ciclismo) traciona a 
 - Leg press 45°: ROM 60–70°, carga −20–25%, pés em rotação externa 15–20°, terço médio-superior da plataforma
 - Aquecimento: foam roll TFL + vasto lateral (5 min), ativação VMO em 30° com rotação externa, clamshell, dorsiflexão no step
 - Wall squat excêntrico (3×8 com excêntrica de 8–10s): mantido ao final de B; removido de D em 18/05 — substituído por cadeira extensora isométrica terminal (20°→0°, 3×10, hold 3s, RPE 4)
-- Pós-treino: alongamento Ober + mobilização patelar passiva + gelo 10–12 min
 
 ### Critérios de progressão
 - **Fase 2:** dor 0–1/10 no leg press restrito por 2 treinos seguidos + wall squat 3×8 sem dor → liberar amplitude/carga progressiva no leg press


### PR DESCRIPTION
### Pedido (Telegram)
Remove todas as atividades de pós-treino (alongamento, mobilização, gelo, banho frio, respiração, recuperação e similares) de todos os dias de treino da série de academia. Mantém aquecimento e exercícios principais. Vale para segunda, terça, quarta, quinta e sexta (ou os dias que houver treino configurado).

### Resumo da mudança
Removidos os blocos 'Pós-treino (~4 min)' dos Treinos B e D (alongamento Ober, mobilização patelar passiva e gelo), e a referência correspondente no Protocolo do Joelho Esquerdo. Aquecimento completo e exercícios principais preservados.

### Arquivos editados
- `serie-academia.md`

### Pareceres dos agents
- **personal-trainer-reviewer** → `approved`: Remoção não impacta volume, progressão nem estrutura do programa. O aquecimento de 13 min permanece intacto.
- **fisioterapeuta-preventivo** → `approved`: O foam roll pré-treino (TFL + vasto lateral) é o momento clinicamente mais relevante para o tracking patelar — já está mantido. Gelo e mobilização patelar podem ser feitos pelo usuário de forma autônoma sem perda de eficácia. O núcleo terapêutico (TKE, isométricos, ativação VMO) permanece intacto.
- **ortopedista-esportivo** → `approved`: Crioterapia e mobilização patelar são medidas de controle sintomático sem janela crítica pós-exercício — podem ser realizadas em casa após o treino. A remoção é aceitável pois o foam roll pré-treino permanece; seria rejeitada se esse elemento fosse removido junto.

---
_Gerado pelo bot-worker do CriaPix. Task id: `0cfaf4241998`._