### PR TITLE
bot: Não tem crunch machine com apoio de peito na academia. É uma cadeira c

### DIFF
--- a/.claude/agent-memory/personal-trainer-reviewer/user_profile.md
+++ b/.claude/agent-memory/personal-trainer-reviewer/user_profile.md
@@ -23,4 +23,6 @@ Aluno masculino, pratica ciclismo (Z2 em dias de treino, Ter/Qua/Sex) e muscula�
 
 **Divisão de treino:** A/B/C/D (Upper A / Lower A / Upper B / Lower B), Seg-Qui
 
-**Equipamentos disponíveis:** Academia com: chest press máquina, remada cavalinho máquina, remada sentada cabo, puxada lat, tríceps pulley, leg press 45°, mesa flexora, cadeira abdutora, cadeira extensora, panturrilha em pé, hip thrust máquina, crunch máquina, máquina de rotação de tronco, cabo com corda e barra reta. Tem elásticos para protocolo de ativação.
+**Equipamentos disponíveis:** Academia com: chest press máquina, remada cavalinho máquina, remada sentada cabo, puxada lat, tríceps pulley, leg press 45°, mesa flexora, cadeira abdutora, cadeira extensora, panturrilha em pé, hip thrust máquina, **cadeira abdominal com punhos overhead** (NÃO tem crunch machine com apoio no peito), máquina de rotação de tronco, cabo com corda e barra reta. Tem elásticos para protocolo de ativação.
+
+**Nota sobre cadeira abdominal (19/05/2026):** Punhos overhead geram demanda isometrica no manguito direito durante todo o set. Cue recomendado: cotovelos a 90° (não elevar acima dos ombros). Pendente validacao multidisciplinar ou ajuste de cue antes de aprovacao definitiva.

--- a/serie-academia.md
+++ b/serie-academia.md
@@ -37,7 +37,7 @@ title: Série de Musculação
 | 7 | **Rosca martelo** [📸](https://static1.minhavida.com.br/articles/39/76/c9/c4/makatserchykshutterstock-orig-1.jpg) | 3 × 10–12 | Pegada neutra; trabalha bíceps + braquial; sem movimentar ombro. |
 | 8 | **Rosca no cabo** (polia baixa, pegada supinada) | 3 × 10–12 | Tensão constante em toda a amplitude — diferente do halter que perde tensão no fundo. Complementa o martelo com ângulo supinado. |
 | 9 | **Rotação externa no cabo** (0°) [📸](https://s32540.pcdn.co/wp-content/uploads/2018/11/rota%C3%A7aoexterna241118-Copy.jpg) | 3 × 15 | Carga LEVE — terapêutico; cotovelo colado ao corpo a 0°; cadência 3-1-2. |
-| 10 | **Abdominal na máquina** (crunch machine) [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2017/09/abdominal-maquina.gif) | 3 × 12–15 | Apoio no PEITO (nunca na nuca); flexão de tronco controlada; RPE 6. |
+| 10 | **Abdominal na máquina** (cadeira abdominal; punhos acima da cabeça) [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2017/09/abdominal-maquina.gif) | 3 × 12–15 | Sentado; segurar os punhos acima da cabeça; **antes de cada série: retrair e deprimir as escápulas ("ombros no bolso de trás das calças") e manter durante todo o movimento** — ombros não sobem; flexão de tronco controlada (não puxar pelos braços); cervical neutra; RPE 6. Interromper se sentir pressão no ombro direito. |
 
 **Volume A:** 29 sets — Peito: 4 · Costas: 6 · Tríceps: 5 · Bíceps: 6 · Core: 3 · Reabilitação: 5
 
@@ -95,7 +95,7 @@ title: Série de Musculação
 | 7 | **Rosca hammer no cabo** (polia baixa, pegada neutra) | 3 × 10–12 | Tensão constante no braquial + bíceps; grip neutro diferente das roscas supinadas. Cabo varia o vetor de força vs. halter. |
 | 8 | **Rosca scott máquina** [📸](https://static1.minhavida.com.br/articles/a0/79/bd/2f/makatserchykshutterstock-orig-1.jpg) | 2 × 10–12 | Apoio completo do cotovelo; máxima contração do bíceps; sem compensação. Finishing set — vem após o hammer para fatiga máxima. |
 | 9 | **Máquina de rotação de tronco** [📸](https://totalpass.com/wp-content/uploads/2025/12/twist1.png) | 2 × 12 (cada lado) | Core rotacional — frequência 2×/semana (complementa Treino D). Carga LEVE; movimento pelo tronco; cervical fixa à frente. |
-| 10 | **Abdominal na máquina** (crunch machine) [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2017/09/abdominal-maquina.gif) | 3 × 12–15 | Apoio no peito; RPE 6. |
+| 10 | **Abdominal na máquina** (cadeira abdominal; punhos acima da cabeça) [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2017/09/abdominal-maquina.gif) | 3 × 12–15 | Sentado; segurar os punhos acima da cabeça; retrair e deprimir escápulas ("ombros no bolso") antes de cada série e manter; flexão de tronco controlada (não puxar pelos braços); cervical neutra; RPE 6. Parar se sentir pressão no ombro direito. |
 
 **Volume C:** 29 sets — Peito: 4 · Costas: 6 · Tríceps: 3 · Bíceps: 8 · Core: 5 · Reabilitação: 3
 
@@ -335,7 +335,7 @@ A série foi desenhada com **variação A vs. C dentro do mesmo mesociclo.** A c
 - **Dor noturna persistente após treino:** sinal de alarme → reduzir RPE do supino para 5 e monitorar por 1 semana
 - **Peitoral:** 8 sets/semana é o limite atual de segurança. Para maximizar ganho dentro desse limite: carga progressiva + contração isométrica de 1–2s no pico em todas as reps
 - **Braços:** bíceps 14 sets/semana com 4 variações (martelo + rosca cabo + direta + scott + hammer cabo) = máxima cobertura angular; tríceps 9 sets com 3 variações (barra bilateral + unilateral + corda)
-- **Core:** 10 sets/semana na academia (abdominal 2× crunch machine em A e C + 2× rollout em B e D; rotação 2×)
+- **Core:** 10 sets/semana na academia (abdominal 2× cadeira abdominal em A e C + 2× rollout em B e D; rotação 2×)
 - **Ciclismo:** hip thrust 4 sets + kick-back glúteo 2 sets + leg press 7 sets + mesa flexora 6 sets + extensora 6 sets + abdutora 4 sets + adutora 6 sets + panturrilha 6 sets = base de força para o pedal
 - **Glúteo máximo:** hip thrust no Treino D (4 sets) = 4 sets/semana
 - **Glúteo médio:** 2×/semana (Treino B + D) — estabilidade lateral no selim; 4 sets/semana


### PR DESCRIPTION
### Pedido (Telegram)
Não tem crunch machine com apoio de peito na academia. É uma cadeira com punhos para pesar acima da cabeça. Ajuste a descrição do exercício de crunch/abdominal na série de peito para refletir esse equipamento disponível.

### Resumo da mudança
Descrição do exercício abdominal nos Treinos A e C atualizada de 'crunch machine com apoio no peito' para 'cadeira abdominal com punhos acima da cabeça', incluindo cue obrigatório de retração/depressão escapular (proteção do ombro direito em reabilitação) e instrução de parada se sentir pressão no ombro. Referência na nota de programação também corrigida.

### Arquivos editados
- `serie-academia.md`

### Pareceres dos agents
- **personal-trainer-reviewer** → `approved`: Cues tecnicamente corretos. Retração/depressão escapular resolve a compensação postural esperada. Variação de redação entre A e C é aceitável — conteúdo equivalente.
- **fisioterapeuta-preventivo** → `approved`: Instrução de depressão escapular cumpre requisito clínico para ombro com rotura parcial bursal, bursite subacromial e acrômio tipo II. Sinal de parada ('pressão no ombro direito') e cervical neutra presentes. Observação não impeditiva: confirmar com personal trainer se cotovelos ficam apoiados nos suportes laterais da máquina (baixo risco se for o caso).

---
_Gerado pelo bot-worker do CriaPix. Task id: `941e918c72eb`._