### PR TITLE
bot: Revisar e adequar minha série de academia completa. Tenho treinado 4-5

### DIFF
--- a/.claude/agent-memory/personal-trainer-reviewer/project_serie_estado_atual.md
+++ b/.claude/agent-memory/personal-trainer-reviewer/project_serie_estado_atual.md
@@ -8,19 +8,21 @@ type: project
 
 **Fase atual:** Fase de Progressão (Mar/2026 → Abr/2026). Última revisão multidisciplinar: 04/03/2026 (5 agentes). Última revisão de série: 02/04/2026 (ajustes de protração escapular).
 
-**Divisão e volumes vigentes (a partir de 18/03/2026):**
+**Última revisão:** 21/05/2026 — revisão de mesociclo (2 meses). Aprovadas: +1 set tríceps em C, RPE máximo abdutora/adutora, recomendação de deload urgente, rotação de Mesociclo +1.
+
+**Divisão e volumes vigentes (a partir de 21/05/2026):**
 
 | Treino | Dia | Volume | Foco principal |
 |--------|-----|--------|----------------|
-| A — Upper A | Seg | 28 sets | Peito, costas horizontal, tríceps, bíceps, core, reabilitação |
-| B — Lower A | Ter | 23 sets | Quadríceps, isquiotibiais, glúteo médio, adutores, panturrilha, core |
-| C — Upper B | Qua | 28 sets | Peito, costas vertical, tríceps, bíceps, core rotacional, reabilitação |
-| D — Lower B | Qui | 26 sets | Glúteo máximo, quadríceps, isquiotibiais, glúteo médio, adutores, panturrilha, core |
+| A — Upper A | Seg | 29 sets | Peito, costas horizontal, tríceps, bíceps, core, reabilitação |
+| B — Lower A | Ter | 22 sets | Quadríceps, isquiotibiais, glúteo médio, adutores, panturrilha, core |
+| C — Upper B | Qua | 30 sets | Peito, costas vertical, tríceps, bíceps, core rotacional, reabilitação |
+| D — Lower B | Qui | 29 sets | Glúteo máximo, quadríceps, isquiotibiais, glúteo médio, adutores, panturrilha, core |
 
 **Volume semanal por grupo (academia):**
 - Peito: 8 sets (limite de segurança atual por causa do ombro)
 - Costas total: 12 sets (6 horizontal + 6 vertical)
-- Tríceps: 9 sets (A:6 + C:3) | Bíceps: 14 sets (A:6 + C:8)
+- Tríceps: 9 sets (A:5 + C:4) — atualizado 21/05/2026 (+1 set corda em C) | Bíceps: 14 sets (A:6 + C:8)
 - Quadríceps: 13 sets (B:7 + D:6) | Isquiotibiais: 6 sets
 - Glúteo máximo: 6 sets (B:2 kick-back + D:4 hip thrust) | Glúteo médio: 4 sets (B:2 + D:2)
 - Adutores: 6 sets (B:3 + D:3) — NOVO, adicionado em 18/03/2026
@@ -50,9 +52,10 @@ type: project
 **Alertas de monitoramento ativos:**
 - Nervo ulnar: volume de bíceps em 14 sets/semana + ciclismo Z2 na Quarta = risco de acúmulo de compressão ulnar. Monitorar formigamento/dormência em 4° e 5° dedos pós-treinos A e C.
 - Proporção quad:isquio (21/05/2026): 15:8 (1,87:1) — dentro do limite 2:1. Volume quad aumentou de 13 para 15 sets com retorno da extensora 0–60° em B e D.
-- Assimetria de proteção escapular: face pull está apenas no Treino C (3 sets). Treino A não tem face pull — avaliação de 02/04/2026 identificou isso como falha residual. Sugerido adicionar 2 sets de face pull em A2 no Treino A.
-- Tabela de volume semanal (seção final do arquivo) contém erro: linha "Reabilitação/terapêutico: 14" é resíduo de versão anterior (incluía protocolo de ativação removido). O correto é 6 sets (3 rot. externa em A + 3 face pull em C). Pendente correção.
+- Face pull: PRESENTE em A2 (2×15) e C2 (3×15). Registro anterior de "falha residual — Treino A sem face pull" era incorreto. Corrigido em 21/05/2026.
 - Volume de quadríceps no Treino D (9 sets) é o teto monitorado da Fase 2: se joelho reagir, reduzir extensora 0–60° de 3 para 2 sets antes de qualquer outra alteração.
+- Triceps: 9 sets/semana (A:5 + C:4) após +1 set em 21/05/2026. 4o set de corda no C5 ocorre com triceps prefatigado — monitorar qualidade de execucao na serie 4 (cotovelos nao podem escapar para frente).
+- Deload urgente (21/05/2026): 2 meses sem deload. Protocolo diferenciado: peito/costas reduz carga 30-40% (mantém volume); quadríceps em protocolo Fase 2 — manter amplitude, reduzir carga adicional 15-20% (nao regredir amplitude).
 
 **Protocolo de ativação de manguito:** REMOVIDO da série em 02/04/2026. Não consta mais em nenhum treino.
 

--- a/serie-academia.md
+++ b/serie-academia.md
@@ -10,6 +10,8 @@ title: Série de Musculação
 > 🦵 **Atualizado 21/05/2026 — Retorno gradual ao protocolo de quadríceps:** joelho esquerdo sem dor (Fase 2 ativa). Cadeira extensora reintroduzida em amplitude limitada (0–60°, −30% carga, RPE 5–6) em B e D; leg press progressivo para 80–90° com carga −10–15%; foam roll e aquecimento de joelho mantidos obrigatoriamente. Próxima reavaliação: 04/06/2026 (amplitude completa só após 3 semanas sem dor).
 >
 > **Atualizada 02/04/2026** — Ajustes de protração escapular: face pull movido para C2 (3×15), remadas com pausa retração+depressão, pré-depressão nas puxadas
+>
+> **Revisão 21/05/2026 (2 meses de mesociclo):** tríceps +1 série no Treino C (3→4 sets, total 9 sets/semana); RPE máximo 7–8 na abdutora e 6–7 na adutora (protocolo de joelho ativo — carga máxima proibida); deload 1 semana recomendado antes da próxima semana de progressão; Mesociclo +1 indicado após deload (ver tabela de rotação).
 
 **Objetivos:** Ganho de peitoral e braço · Redução de gordura abdominal · Fortalecimento de core · Melhora de força para ciclismo
 
@@ -66,10 +68,10 @@ title: Série de Musculação
 | 1 | **Leg press 45°** [📸](https://treinomestre.com.br/wp-content/uploads/2019/06/leg-press-45.jpg) | 3 × 10 | 🦵 **Retorno gradual 21/05:** amplitude **80–90°** (ainda não amplitude completa), carga **−10–15%**, cadência **4-1-3**, RPE 7. Pés em **rotação externa 15–20°**, largura dos ombros, calcanhares no **terço médio-superior** da plataforma. ⚠️ NUNCA permitir retroversão pélvica (bunda sair do apoio); parar descida ANTES de perder curva lombar neutra. Parar se dor reaparecer → retornar a 60–70°. |
 | 2 | **Cadeira extensora** | 3 × 12–15 | 🦵 **Retorno gradual 21/05:** amplitude **limitada 0–60°** (não descer além de 60° de flexão), carga **−30% da normal**, cadência 3-1-2, RPE 5–6. Pé em rotação externa 15–20°; mão no VMO para feedback tátil; sem dor durante todo o movimento. **Palpar polo superolateral da patela esquerda antes de cada série** — se dor à palpação em repouso, substituir pelo TKE no dia. Se dor durante o movimento → retornar ao TKE. |
 | 3 | **Mesa flexora** [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2018/09/execucao-da-mesa-flexora1.jpg) | 3 × 10–12 + 1 × 8–10 unilateral (cada lado) | Isquiotibiais — fase de tração do pedal; tempo controlado; cabeça apoiada neutra. ⚠️ Verificar se máquina tem apoio facial adequado; se não → toalha dobrada para evitar extensão cervical (C5-C7). **Unilateral (1 série):** diagnóstico de assimetria de isquiotibiais L/D. |
-| 4 | **Cadeira abdutora** [📸](https://cdn.muscleandstrength.com/sites/default/files/hip-abduction-machine.jpg) | 3 × 15 | Glúteo médio — estabilidade lateral no selim; RPE 7. Fundamental para não balançar no ciclismo. |
-| 5 | **Cadeira adutora** [📸](https://cdn.muscleandstrength.com/sites/default/files/hip-adduction-machine.jpg) | 3 × 15 | Adutores do quadril — complementa a abdutora; estabilidade pélvica no pedal e prevenção de lesão de virilha. RPE 6. |
+| 4 | **Cadeira abdutora** [📸](https://cdn.muscleandstrength.com/sites/default/files/hip-abduction-machine.jpg) | 3 × 15 | Glúteo médio — estabilidade lateral no selim; RPE **máximo 7–8** — ⚠️ NÃO usar carga máxima absoluta; estresse lateral excessivo pode agravar a entesopatia lateral do joelho esquerdo. **Palpar polo superolateral da patela esquerda antes de cada série** — se dor à palpação em repouso, suspender abdutora e adutora no dia. Fundamental para não balançar no ciclismo. |
+| 5 | **Cadeira adutora** [📸](https://cdn.muscleandstrength.com/sites/default/files/hip-adduction-machine.jpg) | 3 × 15 | Adutores do quadril — complementa a abdutora; estabilidade pélvica no pedal e prevenção de lesão de virilha. RPE **máximo 6–7** — NÃO usar carga máxima absoluta; manter controle muscular em toda a amplitude com joelho em protocolo ativo. |
 | 6 | **Panturrilha em pé** (máquina) [📸](https://www.mundoboaforma.com.br/wp-content/uploads/2022/10/aparelho-panturrilha.jpg) | 3 × 12–15 | Amplitude completa; estabilidade do tornozelo no pedal. |
-| 7 | **Wall squat excêntrico** | 3 × 8 (excêntrica de 8–10s) | 🦵 **Adicionado 14/05.** Descida lenta encostado na parede até ~60° de flexão; sem dor. Finalização do treino para reforço de quadríceps em carga controlada. |
+| 7 | **Wall squat excêntrico** | 3 × 8 (excêntrica de 8–10s) | 🦵 **Adicionado 14/05.** Descida lenta encostado na parede — **parar ANTES de atingir 60° (~50–55° de flexão)**, nunca chegar exatamente a 60° (margem de segurança para excêntrica lenta sem parada mecânica); sem dor. Finalização do treino para reforço de quadríceps em carga controlada. |
 | 8 | **Rollout no trilho em C** [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2017/09/abdominal-maquina.gif) | 3 × 8–10 | Apoio no cotovelo; ajoelhado no carrinho; cadência 3-1-2; amplitude ~60–80% do trilho. **Queixo levemente recolhido — cervical neutra durante todo o movimento**; parar a saída antes de qualquer extensão cervical. |
 
 **Volume B:** 22 sets — Quadríceps: 6 (Extensora 0–60°: 3 + Leg press 3) · Wall squat excêntrico: 3 · Isquiotibiais: 4 · Glúteo médio: 3 · Adutores: 3 · Panturrilha: 3 · Core: 3
@@ -90,14 +92,14 @@ title: Série de Musculação
 | 2 | **Face pull** (corda) [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2019/10/face-pulls.jpg) | 3 × 15 | Carga LEVE; cadência 2-2-3; puxar para altura dos olhos. **No pico: "ombros no bolso de trás das calças" — segurar 2s.** Retratores frescos = qualidade postural máxima. |
 | 3 | **Remada sentada na máquina** [📸](https://static.wixstatic.com/media/2edbed_56a6cbe28714421c96fb1f932516ed07~mv2.jpg) | 3 × 10–12 | Pegada neutra; cadência 2-2-3; **reduzir carga 10-15%**; pausa 1s no pico com retração + depressão simultânea. Máquina guiada = melhor rastreabilidade e menos instabilidade cervical. |
 | 4 | **Puxada frontal fechada** (pegada neutra) [📸](https://treinomestre.com.br/wp-content/uploads/2022/06/puxada-fechada-pegada-supinada.png) | 3 × 10–12 | Pegada mais fechada — ângulo diferente do Treino A; **pré-depressão antes de cada rep: afastar ombros das orelhas antes de puxar**. |
-| 5 | **Tríceps pulley** (corda) [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2018/10/execucao-do-triceps-corda.jpg) | 3 × 12–15 | Corda: ativação diferente da cabeça lateral vs. barra do Treino A. |
+| 5 | **Tríceps pulley** (corda) [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2018/10/execucao-do-triceps-corda.jpg) | 4 × 12–15 | Corda: ativação diferente da cabeça lateral vs. barra do Treino A. 4 sets (era 3) para equalizar volume com Treino A e atingir 9 sets/semana de tríceps — maior músculo do braço. |
 | 6 | **Rosca direta** (barra ou halteres) [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2018/08/rosca-direta-com-barra-1.jpg) | 3 × 10–12 | Pegada supinada — ângulo diferente da rosca martelo; pico de bíceps. |
 | 7 | **Rosca hammer no cabo** (polia baixa, pegada neutra) | 3 × 10–12 | Tensão constante no braquial + bíceps; grip neutro diferente das roscas supinadas. Cabo varia o vetor de força vs. halter. |
 | 8 | **Rosca scott máquina** [📸](https://static1.minhavida.com.br/articles/a0/79/bd/2f/makatserchykshutterstock-orig-1.jpg) | 2 × 10–12 | Apoio completo do cotovelo; máxima contração do bíceps; sem compensação. Finishing set — vem após o hammer para fatiga máxima. |
 | 9 | **Máquina de rotação de tronco** [📸](https://totalpass.com/wp-content/uploads/2025/12/twist1.png) | 2 × 12 (cada lado) | Core rotacional — frequência 2×/semana (complementa Treino D). Carga LEVE; movimento pelo tronco; cervical fixa à frente. |
 | 10 | **Abdominal na máquina** (cadeira abdominal; punhos acima da cabeça) [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2017/09/abdominal-maquina.gif) | 3 × 12–15 | Sentado; segurar os punhos acima da cabeça; retrair e deprimir escápulas ("ombros no bolso") antes de cada série e manter; flexão de tronco controlada (não puxar pelos braços); cervical neutra; RPE 6. Parar se sentir pressão no ombro direito. |
 
-**Volume C:** 29 sets — Peito: 4 · Costas: 6 · Tríceps: 3 · Bíceps: 8 · Core: 5 · Reabilitação: 3
+**Volume C:** 30 sets — Peito: 4 · Costas: 6 · Tríceps: 4 · Bíceps: 8 · Core: 5 · Reabilitação: 3
 
 ---
 
@@ -124,8 +126,8 @@ title: Série de Musculação
 | 2 | **Cadeira extensora** | 3 × 12–15 | 🦵 **Retorno gradual 21/05:** amplitude **limitada 0–60°** (não descer além de 60° de flexão), carga **−30% da normal**, cadência 3-1-2, RPE 5–6. Pé em rotação externa 15–20°; mão no VMO para feedback tátil; sem dor durante todo o movimento. **Palpar polo superolateral da patela esquerda antes de cada série** — se dor à palpação em repouso, substituir pelo TKE no dia. Se dor durante o movimento → retornar ao isométrico de leg press. |
 | 3 | **Leg press 45°** [📸](https://treinomestre.com.br/wp-content/uploads/2019/06/leg-press-45.jpg) | 3 × 10 | 🦵 **Retorno gradual 21/05:** amplitude **80–90°**, carga **−10–15%**, cadência **4-1-3**, RPE 7. Mesmo posicionamento de pés do Treino B. ⚠️ NUNCA permitir retroversão pélvica (bunda sair do apoio); parar descida ANTES de perder curva lombar neutra. Descansar 90–120s após a extensora. Parar se dor reaparecer → retornar a 60–70°. |
 | 4 | **Mesa flexora** [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2018/09/execucao-da-mesa-flexora1.jpg) | 4 × 10–12 | 🦵 **Retornado a 4 séries 21/05** (era 5 séries durante o protocolo de joelho para compensar a redução de quadríceps). Isquiotibiais — fase de tração do pedal. ⚠️ Verificar apoio facial; se inadequado → toalha dobrada para evitar extensão cervical (C5-C7). |
-| 5 | **Cadeira abdutora** [📸](https://cdn.muscleandstrength.com/sites/default/files/hip-abduction-machine.jpg) | 3 × 15 | Glúteo médio — frequência 2×/semana (complementa Treino B); estabilidade lateral no selim. RPE 7. |
-| 6 | **Cadeira adutora** [📸](https://cdn.muscleandstrength.com/sites/default/files/hip-adduction-machine.jpg) | 3 × 15 | Adutores do quadril — par com a abdutora; estabilidade pélvica e prevenção de lesão de virilha. RPE 6. |
+| 5 | **Cadeira abdutora** [📸](https://cdn.muscleandstrength.com/sites/default/files/hip-abduction-machine.jpg) | 3 × 15 | Glúteo médio — frequência 2×/semana (complementa Treino B); estabilidade lateral no selim. RPE **máximo 7–8** — ⚠️ NÃO usar carga máxima absoluta com joelho em protocolo ativo; estresse lateral pode agravar a entesopatia superolateral da patela. **Palpar polo superolateral da patela esquerda antes de cada série** — se dor à palpação, suspender abdutora e adutora no dia. Se fadiga subjetiva de joelho após cadeira extensora: cortar 1 série da abdutora (não do leg press). |
+| 6 | **Cadeira adutora** [📸](https://cdn.muscleandstrength.com/sites/default/files/hip-adduction-machine.jpg) | 3 × 15 | Adutores do quadril — par com a abdutora; estabilidade pélvica e prevenção de lesão de virilha. RPE **máximo 6–7** — NÃO usar carga máxima absoluta; controle total da amplitude. |
 | 7 | **Panturrilha em pé** (máquina) [📸](https://www.mundoboaforma.com.br/wp-content/uploads/2022/10/aparelho-panturrilha.jpg) | 3 × 12–15 | Amplitude completa; frequência 2×/semana. |
 | 8 | **Rollout no trilho reto inclinado** [📸](https://www.hipertrofia.org/blog/wp-content/uploads/2017/09/abdominal-maquina.gif) | 3 × 8–10 | Apoio no cotovelo; ajoelhado no carrinho; cadência 3-1-2; iniciar com ~60% do trilho, progredir amplitude progressivamente. **Queixo levemente recolhido — cervical neutra durante todo o movimento**. |
 | 9 | **Cadeira extensora — isométrico terminal** | 3 × 10 (hold 3s em extensão máxima) | 🦵 **Substituiu wall squat excêntrico em 18/05.** Amplitude restrita a **20°→0° apenas** — não descer além de 20° de flexão. Pé em rotação externa 15–20°; mão no VMO para feedback tátil; hold 3s em extensão máxima; cadência 2-3-3; carga LEVE (RPE 4). Objetivo: recrutar VMO em arco sem estresse de tração na inserção tendínea. Wall squat mantido apenas no Treino B. |
@@ -143,7 +145,7 @@ title: Série de Musculação
 | **Costas horizontal** | 3 | — | 3 | — | **6** |
 | **Costas vertical** | 3 | — | 3 | — | **6** |
 | **Costas total** | 6 | — | 6 | — | **12** |
-| **Tríceps** | 5 | — | 3 | — | **8** |
+| **Tríceps** | 5 | — | 4 | — | **9** |
 | **Bíceps** | 6 | — | 8 | — | **14** |
 | **Glúteo máximo** | — | — | — | 4 | **4** |
 | **Quadríceps** | — | 6 | — | 9 | **15** (🦵 retorno gradual 21/05: extensora 0–60° reintroduzida em B e D) |
@@ -169,7 +171,7 @@ title: Série de Musculação
 - **Braços:** RPE 6–7 — tríceps é o maior músculo do braço; 9 sets com 3 variações + bíceps 14 sets com 4 variações = máximo estímulo dentro das restrições do ombro
 - **Core:** RPE 6 — foco em qualidade e controle
 - **Reabilitação (rot. ext / face pull):** RPE 4–5 — carga leve sempre, foco em execução
-- **Deload** a cada 4–6 semanas: reduzir carga 30–40% por 1 semana
+- **Deload** a cada 4–6 semanas: reduzir carga 30–40% por 1 semana. **⚠️ Maio/2026: 2 meses com o mesmo mesociclo — deload imediato recomendado (1 semana) antes de retomar progressão.** Durante o deload: compostos principais −30–40%; cadeira extensora e leg press de Fase 2 mantidos em carga normal (protocolo terapêutico não regride); wall squat excêntrico reduz para 2×5 com excêntrica de 5s. Após deload, iniciar Mesociclo +1: Upper A puxada → máquina guiada (descida reta); Lower D leg press → horizontal/sentado **somente após liberação do protocolo de joelho** (avaliação 04/06/2026) e com carga inicial 20–25% menor que o 45° atual.
 
 ---
 


### PR DESCRIPTION
### Pedido (Telegram)
Revisar e adequar minha série de academia completa. Tenho treinado 4-5x/semana há 2 meses com a mesma série. Objetivo: ganhar volume em peitoral e braços, mantendo força nas pernas para MTB. Progressão atual: 12 reps aumentando peso. Restrições de joelho: dor lateral externa (já melhorou, mas ainda com cuidado em leg press 45º e extensora). Detalhe importante: uso peso máximo em abdutora e adutora também. Quero que vocês avaliem se faz sentido mudar o treino todo ou só ajustar, otimizando estímulo de hipertrofia em braços/peito e preservando força funcional nas pernas sem agredir o joelho.

### Resumo da mudança
Série ajustada (não reformulada): +1 série de tríceps no Treino C (3→4, total 9 sets/semana); RPE máximo 7–8 na abdutora e 6–7 na adutora com palpação pré-série obrigatória; wall squat limitado a 50–55° (margem de segurança excêntrica); deload imediato recomendado com instruções específicas para protocolo de joelho; Mesociclo +1 mapeado após deload e liberação clínica de 04/06.

### Arquivos editados
- `serie-academia.md`

### Pareceres dos agents
- **personal-trainer-reviewer** → `approved`: +1 série tríceps corrige assimetria de volume entre Upper A (5 sets) e Upper C (3 sets); RPE cap abdutora/adutora era necessário desde a Fase 2; deload após 2 meses é urgente; Mesociclo +1 condicionado ao joelho é tecnicamente correto. Sugestão não bloqueante: detalhar que o protocolo terapêutico do joelho não regride amplitude durante o deload — incorporado na nota de deload.
- **fisioterapeuta-preventivo** → `approved`: RPE cap na abdutora aprovado (co-ativação do TFL com carga máxima amplificaria tração lateral na patela — mecanismo direto de agravo da entesopatia); wall squat corrigido para 50–55° (margem de segurança para excêntrica lenta sem parada mecânica); deload terapêutico (tendão em resolução de entesopatia necessita descarga cumulativa); proporção quad:isquio 1,87:1 é risco prospectivo — recomenda aumento da mesa flexora ao entrar na Fase 3.
- **ortopedista-esportivo** → `approved`: RPE cap abdutora aprovado com adição de palpação pré-série (cláusula aplicada por analogia com a cadeira extensora); deload fortemente endossado (descarga tendínea cumulativa); Mesociclo +1 leg press horizontal aprovado condicionalmente com carga inicial 20–25% menor; nota de fadiga cumulativa Lower D incorporada (cortar abdutora, não leg press, se fadiga de joelho após extensora).

---
_Gerado pelo bot-worker do CriaPix. Task id: `9809acdb80b2`._