### PR TITLE
Adiciona resultado da PAAF da tireoide (Bethesda IV) e consulta endocrinologista

### DIFF
--- a/Laudos/citopatologico_tireoide_paaf_09-06-2026.txt
+++ b/Laudos/citopatologico_tireoide_paaf_09-06-2026.txt
@@ -1,0 +1,43 @@
+EXAME CITOPATOLÓGICO DE TIREOIDE — PAAF GUIADA POR ULTRASSONOGRAFIA
+Protocolo: RJC26-2408 / Atendimento 0348302
+Paciente: Patrick Santos Coelho — DN 20/09/1978 (47 anos), Masculino
+Médico solicitante: Dr. Mario Lucio Cordeiro Araujo Junior (CRM/RJ 757810)
+Data da coleta: 09/06/2026 — Data de recebimento: 10/06/2026
+Liberado por: Dr. Mario Lucio Cordeiro Araujo Junior (CRM/RJ 5275781-0) em 11/06/2026
+
+INFORMAÇÕES CLÍNICAS / HIPÓTESE DIAGNÓSTICA
+Nódulo em lobo direito (terço inferior) da tireoide, hipoecogênico, com margens
+regulares, orientação paralela, sem calcificações e vascularização periférica e
+central (P > C), medindo 0,9 x 0,6 x 0,5 cm. TIRADS 4.
+
+PROCEDIMENTO
+- Punção aspirativa por agulha fina (PAAF) guiada por ultrassonografia
+- Topografia da punção: lobo direito (terço inferior)
+- Lâminas recebidas/processadas: 5 (3 secas ao ar, 1 fixada em álcool e 1 cell block)
+- Espécime/colorações: convencional / cell block — panótico / papanicolaou / H&E
+
+MICROSCOPIA
+- Avaliação da amostra: amostra adequada e representativa
+- Achados citopatológicos: amostra composta exclusivamente por células foliculares
+  de padrão oncocítico, em fundo hemático com escasso coloide. Ausência de atipias
+  citológicas marcantes.
+
+CONCLUSÃO
+PAAF guiada por US de nódulo em lobo direito (terço inferior) da tireoide:
+• Classificação pelo Sistema Bethesda (tireoide): NEOPLASIA FOLICULAR, do tipo
+  ONCOCÍTICA (CATEGORIA IV)
+
+NOTAS
+- A categoria "neoplasia folicular" pode corresponder a doença folicular nodular,
+  adenoma ou carcinoma folicular, ou ainda subtipo folicular do carcinoma papilífero.
+  A caracterização definitiva só pode ser feita por exame histológico do nódulo
+  (avaliação de sinais de invasão e características nucleares).
+- Risco de malignidade por categoria Bethesda: I-Não diagnóstico (5-20%);
+  II-Benigno (2-7%); III-Atipia de significado indeterminado (13-30%);
+  IV-Neoplasia folicular (23-34%, inclui oncocítica / antes "células de Hürthle");
+  V-Suspeito (67-83%); VI-Maligno (97-100%).
+
+Referência: Ali SZ; Vanderlaan PA. The Bethesda System for Reporting Thyroid
+Cytopathology, 3rd ed. Springer Nature, 2023.
+
+09/06/2026

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,27 @@ Historico de alteracoes no plano de treino, nutricao e acompanhamento clinico.
 
 ---
 
+## 18/06/2026 — Resultado da PAAF da tireoide (Bethesda IV) + consulta endocrinologista
+
+**Contexto:** chegou o laudo do citopatologico da tireoide (PAAF guiada por US, coleta 09/06/2026, liberado 11/06/2026) e o paciente passou em consulta com a endocrinologista em 18/06/2026.
+
+**Resultado da PAAF (RJC26-2408):**
+- Nodulo do lobo direito (0,9 cm) puncionado; amostra adequada e representativa.
+- Citologia: celulas foliculares de padrao oncocitico, sem atipias marcantes.
+- **Classificacao Bethesda: CATEGORIA IV — neoplasia folicular oncocitica** (antes "celulas de Hurthle").
+- Risco de malignidade da categoria: **23-34%** (maioria benigna, mas a citologia nao distingue benigno x maligno — definicao exige histologia do nodulo).
+
+**Conduta da endocrinologista (18/06/2026):**
+- **Sem urgencia** — nodulo pequeno (0,9 cm).
+- **Acompanhamento a cada 6 meses** (proximo controle ~dez/2026).
+- **Encaminhamento para cirurgiao de cabeca e pescoco** para avaliar a conduta sobre o nodulo Bethesda IV.
+
+**Mudancas aplicadas:**
+- Novo laudo arquivado: `Laudos/citopatologico_tireoide_paaf_09-06-2026.txt`
+- `dados-saude.md`: Secao 12 (subsecoes PAAF + consulta endocrinologista), Secao 14 (status PAAF/endocrino), Pendencias 2 e 3 reescritas (cirurgiao de cabeca e pescoco + acompanhamento semestral)
+
+---
+
 ## 10/06/2026 — Joelho recuperado + rebalanceamento de volume inferiores→superiores
 
 **Contexto:** paciente informou alta funcional do joelho esquerdo (entesopatia quadricipital lateral resolvida) e retorno aos exercicios de perna em amplitude/carga normais. Pergunta: vale reduzir inferiores e aumentar superiores?

--- a/dados-saude.md
+++ b/dados-saude.md
@@ -230,8 +230,19 @@ Demais marcadores normais: eletrólitos, função hepática/renal, hemograma, te
 #### US Tireoide com Doppler (03/03/2026)
 - Nódulo 0,9 cm lobo direito — **TIRADS 4**, Chammas IV. Contorno regular, sem calcificações
 - Parênquima heterogêneo → possível Hashimoto (anti-TPO pendente)
-- PAAF não indicada (< 1,5 cm para TIRADS 4)
-- **Ação:** endocrinologista + anti-TPO + US controle 6-12 meses
+- **Ação:** endocrinologista + anti-TPO + acompanhamento
+
+#### PAAF / Citopatológico de Tireoide (09/06/2026)
+- Punção aspirativa por agulha fina (PAAF) guiada por US do nódulo do lobo direito (terço inferior)
+- Amostra **adequada e representativa**; células foliculares de **padrão oncocítico**, sem atipias marcantes
+- **Resultado: Neoplasia folicular oncocítica — Bethesda CATEGORIA IV**
+- **Risco de malignidade 23-34%** (maioria benigna, mas indistinguível só pela citologia — diferenciar benigno × maligno exige exame histológico do nódulo)
+- > Laudo completo em `Laudos/citopatologico_tireoide_paaf_09-06-2026.txt`
+
+#### Consulta Endocrinologista (18/06/2026)
+- **Sem urgência** — nódulo pequeno (0,9 cm)
+- Conduta: **acompanhamento a cada 6 meses**
+- **Encaminhamento para cirurgião de cabeça e pescoço** (avaliar conduta sobre o nódulo Bethesda IV)
 
 ---
 
@@ -271,7 +282,9 @@ Demais marcadores normais: eletrólitos, função hepática/renal, hemograma, te
 
 - **Exames (RM ombro, cervical, dorsal):** ✅ REALIZADOS em 02/02/2026
 - **Exames de sangue:** ✅ REALIZADOS em 10/02/2026
-- **US tireoide com Doppler:** ✅ REALIZADO em 03/03/2026 — TIRADS 4 (0,9 cm, lobo direito) + parênquima heterogêneo → endocrinologista + anti-TPO pendentes
+- **US tireoide com Doppler:** ✅ REALIZADO em 03/03/2026 — TIRADS 4 (0,9 cm, lobo direito) + parênquima heterogêneo
+- **PAAF tireoide:** ✅ REALIZADA em 09/06/2026 — **Bethesda IV** (neoplasia folicular oncocítica; risco de malignidade 23-34%)
+- **Consulta endocrinologista:** ✅ REALIZADA em 18/06/2026 — sem urgência (nódulo pequeno); acompanhamento a cada 6 meses + encaminhamento para cirurgião de cabeça e pescoço
 - **Bioimpedância 04/04/2026:** ✅ **MELHOR RESULTADO DO HISTÓRICO** — FFM 65,1 kg (novo recorde); BF 11,7% (novo recorde, ⚠️ próximo ao limite inferior 11%); SMM 39,3 kg (novo recorde); TBW 47,7 L; VFL 4; Idade metabólica 36 (novo mínimo)
 - **Fisioterapia:** ❌ NÃO será realizada — decisão do paciente (02/04/2026). Série de academia compensa com rigor técnico máximo
 - **Dor:** sem dor intensa durante treinos; restrições severas mantidas (ombro + cervical)
@@ -283,8 +296,8 @@ Demais marcadores normais: eletrólitos, função hepática/renal, hemograma, te
 
 ### Pendências ativas
 1. ✅ **Exames laboratoriais (CK, ENMG, painel completo):** todos realizados e analisados pelo médico (confirmado pelo paciente em 14/05/2026) — resultados arquivados; reavaliar individualmente conforme indicação clínica
-2. 🔴 **Consulta endocrinologista** + **anti-TPO** — avaliar TIRADS 4 + parênquima heterogêneo
-3. ⚠️ **US tireoide controle** — 6-12 meses (set/2026-mar/2027)
+2. 🔴 **Consultar cirurgião de cabeça e pescoço** — encaminhado pela endocrinologista (18/06/2026) para avaliar conduta sobre o nódulo Bethesda IV
+3. ⚠️ **Acompanhamento da tireoide a cada 6 meses** — próximo controle ~dez/2026 (sem urgência; nódulo pequeno). Manter **anti-TPO** pendente para investigar parênquima heterogêneo (possível Hashimoto)
 4. ⚠️ **BF% em 11,7%** — monitorar na próxima bio; se cair abaixo de 11%, aumentar calorias nos dias de treino
 5. ✅ **Joelho esquerdo — RECUPERADO (10/06/2026):** entesopatia do tendão quadricipital lateral resolvida; exercícios de perna em amplitude completa e carga normal. Mantida manutenção preventiva (foam roll TFL + VMO + clamshell) por causa do ciclismo. Ver Seção 17.
 6. 🎯 **Meta bio ~mai/2026:** FFM >= 65,0 · SMM >= 39,0 · BF% >= 11,0% (não cair abaixo) · VFA <= 26 · VFL = 4


### PR DESCRIPTION
- Novo laudo: Laudos/citopatologico_tireoide_paaf_09-06-2026.txt
- dados-saude.md: PAAF (Bethesda IV, neoplasia folicular oncocitica),
  consulta endocrinologista 18/06 (sem urgencia, acompanhamento 6 meses,
  encaminhamento cirurgiao cabeca e pescoco); status e pendencias atualizados
- changelog.md: entrada 18/06/2026

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GzUdG3SZHbTnGix4ickb7k