### PR TITLE
Arquitetura de informação orientada aos momentos de uso

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,64 @@ Exercícios, refeições, suplementos, laudos e medições são **registros com 
 o que antes estava escrito à mão: total de séries por grupo, plano do dia, gráficos,
 busca e checklists.
 
+## Arquitetura de informação: operar × consultar
+
+O app tem duas naturezas de conteúdo e elas não se misturam:
+
+- **Operar** — o que se faz várias vezes por dia. Três telas, cada uma com um trabalho.
+- **Consultar** — plano completo, exames, laudos, histórico, balanço da semana. Se lê de vez
+  em quando; não pode competir por espaço com a operação.
+
+A navegação inferior tem exatamente quatro itens:
+
+| Aba | Responde | Contém |
+|---|---|---|
+| **Hoje** | o que eu faço agora? | uma ação em destaque, quatro atalhos, no máximo um alerta |
+| **Comer** | o que preciso comer? como registro? | progresso do dia, refeição da vez, lista do cardápio, suplementos |
+| **Treinar** | qual série? como registro série e pedal? | série de hoje (ou a sugerida), registro de pedal, o que já entrou |
+| **Consultar** | onde está aquilo? | todo o resto, agrupado |
+
+### Os momentos de uso, e onde cada um resolve
+
+O desenho partiu dos cinco momentos frequentes, não das entidades do domínio:
+
+| Momento | Caminho | Toques |
+|---|---|---|
+| saber o que preciso comer | Comer → refeição da vez em destaque | 1 |
+| registrar o que comi | Comer → **Comi isso**, ou **Comi outra coisa** para compor | 2 |
+| saber qual série tenho que fazer | Treinar → série sugerida no topo | 1 |
+| registrar a série que fiz | Treinar → **Começar o treino X** → marcar série por série | 2 |
+| registrar o pedal que fiz | Treinar → perfil, duração, **Registrar pedal** | 3 |
+
+**Hoje calcula a próxima ação** em vez de listar tudo (`proximaAcao` no motor), por ordem de
+prazo real: janela anabólica aberta (30 min) → refeição da hora → série sugerida → dia fechado.
+O cartão muda de cor com a urgência e leva direto ao lugar de agir.
+
+**Treinar abre na série quando já há treino registrado.** Na academia o que importa é a lista
+de exercícios com as marcações, não um painel — então o painel some.
+
+### Teto de alertas
+
+O problema anterior era acúmulo: orientações do dia, alertas da janela e alertas clínicos
+contínuos empilhados na mesma tela. Agora:
+
+- **Hoje** mostra **um** alerta — o mais urgente. O resto vira `Ver todos os alertas (n)`, que
+  abre uma folha com três grupos: do dia, da janela, atenção contínua.
+- **Comer** mostra só os avisos que mudam o que se vai comer agora.
+- **Treinar** mostra só as ressalvas da sessão sugerida.
+- Alerta clínico contínuo (ombro, composição corporal, cirurgião) não é do dia: vive na folha
+  de alertas e em Consultar → Saúde.
+
+Efeito medido no navegador, com o mesmo estado: a tela Hoje passou de **~10 300 px** de altura
+para **~1 000 px** — cabe numa tela e meia em vez de dez.
+
 ## Modo flexível: registrar e deixar o app se ajustar
 
 Não há programação fixa por dia da semana. Você registra o que fez e o app recalcula.
 
-**O que se registra** (aba Hoje): `Pedalei` e `Malhei` (escolhendo a série) — mais de uma
-execução por dia é aceita. As refeições do plano são marcadas uma a uma, ou
-[personalizadas](#personalizar-refeições) com o que você realmente comeu.
+**O que se registra** (aba Treinar): pedal e série, mais de uma execução por dia. As refeições
+são marcadas na aba Comer, uma a uma, ou [personalizadas](#personalizar-refeições) com o que
+você realmente comeu.
 
 **O que se registra, em detalhe.** Cada execução leva **duração** e, no pedal, um **perfil de
 intensidade**; o gasto estimado aparece no botão antes de gravar e continua editável depois
@@ -93,7 +144,7 @@ apenas nos treinos B e D). Se você já comeu como dia leve e depois treinou, el
 alvo subiu e quanto falta repor. Os macros de cada refeição são gravados no momento da
 marcação, então mudar o tipo do dia depois não reescreve o que já foi comido.
 
-**Ajuste semanal — janela móvel de 7 dias** (aba Semana). A cada dia o app olha os 7 dias
+**Ajuste semanal — janela móvel de 7 dias** (Consultar → Últimos 7 dias). A cada dia o app olha os 7 dias
 anteriores, em vez de uma semana de calendário: treinar no domingo conta e não existe virada
 que zera o progresso. Metas da janela: 4 academias e 3 pedais. Mostra o que falta,
 o que sai da janela nos próximos dias, o volume por grupo muscular comparado ao alvo semanal
@@ -108,8 +159,9 @@ da série, e a próxima sessão sugerida.
 3. 24h desde a última sessão e 48h para a mesma categoria (superior/inferior).
 4. A ordem de prioridade configurada em `treinos.plano.prioridadeParcial`.
 
-Quando tudo tem ressalva, escolhe a menos bloqueada. A aba Semana mostra numa tabela por que
-cada sessão foi ou não escolhida.
+Quando tudo tem ressalva, escolhe a menos bloqueada — e a ressalva aparece no cartão da série
+em Treinar. Consultar → Últimos 7 dias mostra numa tabela por que cada sessão foi ou não
+escolhida.
 
 **Semanas curtas.** Se não couberem as 4 sessões, a ordem atual é **A → C → B → D**
 (superiores primeiro), escolhida pelo usuário em 30/07/2026 para atender o objetivo de ganho
@@ -118,22 +170,28 @@ prioridade absoluta (~40% da massa muscular) pela transferência ao pedal; o app
 avisando quando os inferiores passam 7 dias sem estímulo. Para inverter, troque
 `treinos.plano.prioridadeParcial.ordem` para `["B","D","A","C"]`.
 
-### Demais abas
+### O que há em Consultar
 
-- **Treino** — sessões A/B/C/D com cartões de exercício (séries × reps, cues, alertas,
-  marcação de séries feitas), volume semanal, progressão, restrições e rotação. A lista
-  marca qual é a `próxima` e quais já foram `✓ feitas` na janela.
-- **Nutrição** — um painel por tipo de dia (abre no tipo derivado de hoje), suplementos,
-  estratégias e metas.
+- **Nutrição** — um painel por tipo de dia (abre no tipo derivado de hoje), tabela de
+  alimentos, compensação do gasto, suplementos, estratégias e metas.
+- **Série de musculação** — sessões A/B/C/D com cartões de exercício (séries × reps, cues,
+  alertas, marcação de séries feitas), volume semanal, progressão, restrições e rotação. A
+  lista marca qual é a `próxima` e quais já foram `✓ feitas` na janela.
+- **Ciclismo** — rotina, protocolo do joelho, plano de resistência e cuidados.
+- **Últimos 7 dias** — o que foi feito, gasto e balanço calórico dia a dia, volume por grupo,
+  limites clínicos, por que cada sessão foi escolhida, exportar/importar o registro.
 - **Saúde** — resumo clínico, composição corporal com gráficos, exames, laudos e pendências.
-- **Mais** (`⋯`) — pedal, dermatologia, histórico, pareceres, perfil, editor, tema, bloquear.
+- **Dermatologia · Histórico · Pareceres · Perfil · Editar dados.**
+- **Ir direto** — atalhos vindos de `perfil.atalhos` para sub-abas específicas.
 - **Busca global** (ícone de lupa ou `Ctrl/Cmd+K`) sobre todos os documentos decifrados.
+- `⋯` no topo — Consultar, editor, bloquear e tema.
 
 ### Onde o registro fica guardado
 
 No `localStorage` do navegador, em `rs.registro`, com 180 dias de retenção. O app é estático
 e não tem servidor, então **não há sincronização entre aparelhos**: use *Exportar registro* /
-*Importar* na aba Semana para levar o histórico de um dispositivo a outro ou fazer backup —
+*Importar* em Consultar → Últimos 7 dias para levar o histórico de um aparelho a outro ou
+fazer backup —
 limpar os dados do site apaga o registro.
 
 ## Compensação do gasto calórico
@@ -177,8 +235,9 @@ isso responde por um terço a metade do gasto e não compete com as refeições.
 itens que já estão no seu cardápio (arroz, batata, macarrão, tapioca, pão, banana, aveia, mel)
 para fechar a diferença.
 
-Onde ver: **Hoje** mostra a conta (base · gasto · alvo), o combustível, o reforço e o banco;
-**Semana** mostra gasto/alvo/comido/saldo dia a dia e o balanço da janela; **Nutrição →
+Onde ver: **Comer** mostra o alvo, o que falta, o combustível, o reforço e o banco; **Treinar**
+mostra o gasto de cada atividade registrada, editável; **Consultar → Últimos 7 dias** mostra
+gasto/alvo/comido/saldo dia a dia e o balanço da janela; **Consultar → Nutrição →
 Compensação** é a referência completa, com uma tabela de quanto comer para cada duração de
 pedal.
 
@@ -233,8 +292,10 @@ do plano; o rateio por refeição foi calculado a partir das quantidades dos ali
 
 O cardápio é uma sugestão, não um contrato. Cada refeição tem duas ações:
 
-- **marcar** (toque na linha) — comeu como no plano, entram os macros planejados;
-- **personalizar** (ícone de lápis) — abre o compositor com a composição do plano já carregada;
+- **marcar** (toque na linha, ou **Comi isso** na refeição da vez) — comeu como no plano,
+  entram os macros planejados;
+- **personalizar** (ícone de lápis, ou **Comi outra coisa**) — abre o compositor com a
+  composição do plano já carregada;
   você troca, tira e ajusta as quantidades, e o que entra na conta do dia são os macros do que
   foi montado.
 

--- a/app/main.js
+++ b/app/main.js
@@ -8,6 +8,9 @@ import { Store, Registro, montarIndiceBusca, buscar } from './store.js';
 import { h, icone, carregando, realcar, toast, aviso } from './ui.js';
 
 import * as vHoje from './views/hoje.js';
+import * as vComer from './views/comer.js';
+import * as vTreinar from './views/treinar.js';
+import * as vConsultar from './views/consultar.js';
 import * as vSemana from './views/semana.js';
 import * as vTreino from './views/treino.js';
 import * as vPedal from './views/pedal.js';
@@ -17,13 +20,21 @@ import * as vMais from './views/mais.js';
 
 /* ===================== definição das seções ===================== */
 
+// `principal` = aba inferior. São quatro, e correspondem aos momentos de uso:
+// decidir o que fazer agora (Hoje), comer, treinar/pedalar e consultar o resto.
+// Tudo mais é alcançado por Consultar, pela busca ou por link direto.
 const SECOES = [
   { id: 'hoje', nome: 'Hoje', icone: 'hoje', cor: 'var(--c-hoje)', principal: true, render: vHoje.render },
-  { id: 'semana', nome: 'Semana', icone: 'historico', cor: 'var(--c-hoje)', principal: true, render: vSemana.render },
-  { id: 'treino', nome: 'Treino', icone: 'treino', cor: 'var(--c-treino)', principal: true, render: vTreino.render },
-  { id: 'pedal', nome: 'Pedal', icone: 'pedal', cor: 'var(--c-pedal)', render: vPedal.render },
-  { id: 'nutricao', nome: 'Nutrição', icone: 'nutricao', cor: 'var(--c-nutricao)', principal: true, render: vNutricao.render },
-  { id: 'saude', nome: 'Saúde', icone: 'saude', cor: 'var(--c-saude)', principal: true, render: vSaude.render },
+  { id: 'comer', nome: 'Comer', icone: 'nutricao', cor: 'var(--c-nutricao)', principal: true, render: vComer.render },
+  { id: 'treinar', nome: 'Treinar', icone: 'treino', cor: 'var(--c-treino)', principal: true, render: vTreinar.render },
+  { id: 'consultar', nome: 'Consultar', icone: 'lista', cor: 'var(--c-geral)', principal: true, render: vConsultar.render },
+
+  // Referência, alcançada por Consultar.
+  { id: 'nutricao', nome: 'Nutrição', icone: 'nutricao', cor: 'var(--c-nutricao)', render: vNutricao.render },
+  { id: 'treino', nome: 'Série de musculação', icone: 'treino', cor: 'var(--c-treino)', render: vTreino.render },
+  { id: 'pedal', nome: 'Ciclismo', icone: 'pedal', cor: 'var(--c-pedal)', render: vPedal.render },
+  { id: 'semana', nome: 'Últimos 7 dias', icone: 'historico', cor: 'var(--c-hoje)', render: vSemana.render },
+  { id: 'saude', nome: 'Saúde', icone: 'saude', cor: 'var(--c-saude)', render: vSaude.render },
   { id: 'dermatologia', nome: 'Dermatologia', icone: 'derma', cor: 'var(--c-derma)', render: vMais.dermatologia },
   { id: 'historico', nome: 'Histórico', icone: 'historico', cor: 'var(--c-geral)', render: vMais.historico },
   { id: 'pareceres', nome: 'Pareceres', icone: 'parecer', cor: 'var(--c-geral)', render: vMais.pareceres },
@@ -92,11 +103,11 @@ function montarNavegacao() {
   // coluna lateral (desktop)
   el.rail.replaceChildren(
     h('div.rail-grupo', null,
-      h('p.rail-titulo', { texto: 'Rotina' }),
-      ...SECOES.filter((s) => s.principal).map(itemRail)
+      h('p.rail-titulo', { texto: 'Operar' }),
+      ...SECOES.filter((s) => s.principal && s.id !== 'consultar').map(itemRail)
     ),
     h('div.rail-grupo', null,
-      h('p.rail-titulo', { texto: 'Registros' }),
+      h('p.rail-titulo', { texto: 'Consultar' }),
       ...SECOES.filter((s) => !s.principal && s.id !== 'editor').map(itemRail)
     ),
     h('div.rail-grupo', null,
@@ -151,10 +162,9 @@ function menuMais() {
   );
 
   abrirSheet(h('div', null,
-    h('p.sheet-titulo', { texto: 'Registros' }),
-    h('div.pilha-2', null, SECOES.filter((s) => !s.principal && s.id !== 'editor').map(item)),
     h('p.sheet-titulo', { texto: 'Dados' }),
     h('div.pilha-2', null,
+      item(porId('consultar')),
       item(porId('editor')),
       h('button.nav-card', {
         type: 'button', estilo: { '--accent': 'var(--c-critico)' },

--- a/app/motor.js
+++ b/app/motor.js
@@ -210,6 +210,113 @@ export function descreverComposicao(alimentos, composicao) {
     .join(' + ');
 }
 
+/* ===================== o que fazer agora ===================== */
+
+/**
+ * Hora aproximada de uma refeição, em horas decimais, a partir do rótulo do
+ * cardápio ("~5:30", "~12h"). As refeições ancoradas em evento — "após o
+ * treino", "durante o pedal" — não têm hora e devolvem null: elas são
+ * disparadas pela atividade, não pelo relógio.
+ */
+export function horaDaRefeicao(refeicao) {
+  const m = String(refeicao.hora || '').match(/(\d{1,2})(?::(\d{2}))?/);
+  if (!m) return null;
+  if (/minuto/i.test(refeicao.hora)) return null; // "minuto 45" é do treino, não do dia
+  return Number(m[1]) + (m[2] ? Number(m[2]) / 60 : 0);
+}
+
+/**
+ * A refeição que vem agora: entre as pendentes, a de hora mais próxima que
+ * ainda não passou; se todas já passaram, a mais atrasada. Refeições ancoradas
+ * em evento entram apenas quando a atividade correspondente foi registrada.
+ */
+export function proximaRefeicao(resumo, agoraH = new Date().getHours() + new Date().getMinutes() / 60) {
+  const candidatas = resumo.pendentes.filter((r) => {
+    if (horaDaRefeicao(r) !== null) return true;
+    // ancorada em evento: só depois de haver atividade registrada
+    return resumo.atividades.length > 0;
+  });
+  if (!candidatas.length) return null;
+
+  // Ancoradas em evento são as mais urgentes: a janela anabólica não espera.
+  const porEvento = candidatas.find((r) => r.janelaAnabolica);
+  if (porEvento) return porEvento;
+
+  const comHora = candidatas
+    .map((r) => ({ r, h: horaDaRefeicao(r) }))
+    .filter((x) => x.h !== null)
+    .sort((a, b) => a.h - b.h);
+  if (!comHora.length) return candidatas[0];
+
+  const aVir = comHora.find((x) => x.h >= agoraH - 0.5);
+  return (aVir || comHora[comHora.length - 1]).r;
+}
+
+/**
+ * A única coisa que o app precisa dizer ao abrir: o que fazer agora. Devolve
+ * `{ tipo, titulo, texto, rota, acao }` — a tela Hoje só renderiza.
+ *
+ * A ordem é de urgência real, não de importância abstrata: o que tem prazo
+ * (janela anabólica, combustível) vem antes do que pode esperar.
+ */
+export function proximaAcao(dados, dia, jan) {
+  const agora = new Date();
+  const h = agora.getHours() + agora.getMinutes() / 60;
+
+  // 1. Janela anabólica aberta — prazo de 30 min.
+  const anabolica = dia.pendentes.find((x) => x.janelaAnabolica);
+  if (dia.atividades.length && anabolica) {
+    return {
+      tipo: 'refeicao',
+      urgencia: 'critico',
+      titulo: anabolica.nome,
+      texto: `${anabolica.itens} — janela de 30 min depois da atividade.`,
+      rota: '#/comer',
+      acao: 'Registrar agora'
+    };
+  }
+
+  // 2. Refeição da hora.
+  const prox = proximaRefeicao(dia, h);
+  if (prox) {
+    const hr = horaDaRefeicao(prox);
+    const atrasada = hr !== null && h > hr + 1;
+    return {
+      tipo: 'refeicao',
+      urgencia: atrasada ? 'atencao' : 'info',
+      titulo: `${prox.nome}${hr !== null ? ` · ${prox.hora}` : ''}`,
+      texto: atrasada ? `${prox.itens} — passou da hora.` : prox.itens,
+      rota: '#/comer',
+      acao: 'Ver e registrar'
+    };
+  }
+
+  // 3. Nada pendente para comer: sobra o treino.
+  if (!dia.sessoes.length && jan.proxima.escolhida) {
+    const s = jan.proxima.escolhida.sessao;
+    return {
+      tipo: 'treino',
+      urgencia: 'info',
+      titulo: `Treino ${s.id} — ${s.nome}`,
+      texto: `${s.foco.join(' · ')} · ~${s.duracaoMin} min.`,
+      rota: '#/treinar',
+      acao: 'Abrir a série'
+    };
+  }
+
+  // 4. Dia cumprido.
+  return {
+    tipo: 'ok',
+    urgencia: 'ok',
+    titulo: 'Dia fechado',
+    texto: dia.sessoes.length
+      ? 'Refeições marcadas e treino registrado. Nada pendente.'
+      : 'Todas as refeições do cardápio já foram marcadas.',
+    rota: '#/comer',
+    acao: 'Revisar o dia'
+  };
+}
+
 /* ===================== tipo de dia derivado ===================== */
 
 /**

--- a/app/views/comer.js
+++ b/app/views/comer.js
@@ -1,0 +1,245 @@
+// Aba "Comer" — responde a duas perguntas e nada mais:
+//   1. o que eu preciso comer agora?
+//   2. como eu registro o que comi?
+//
+// Tudo que é referência (tabela de alimentos, compensação, estratégias, metas)
+// fica em Consultar → Nutrição. Aqui só entra o que é do dia de hoje.
+
+import {
+  h, icone, cabecalhoPagina, aviso, chip, secao, toast, dataLonga, barraMacro
+} from '../ui.js';
+import {
+  resumoDia, bancoCalorico, suplementosDoDia,
+  proximaRefeicao, horaDaRefeicao, descreverComposicao
+} from '../motor.js';
+import { abrirCompositor } from './compositor.js';
+
+export async function render(ctx) {
+  const { store, registro } = ctx;
+  const [perfil, treinos, nutricao, pedal] = await store.docs('perfil', 'treinos', 'nutricao', 'pedal');
+  const dados = { perfil, treinos, nutricao, pedal };
+
+  const dia = resumoDia(dados, registro);
+  const alimentos = nutricao.alimentos;
+  const prox = proximaRefeicao(dia);
+
+  const raiz = h('div');
+  raiz.append(cabecalhoPagina({
+    kicker: dataLonga(new Date()),
+    titulo: 'Comer',
+    subtitulo: dia.provisorio
+      ? `Alvo provisório de ${dia.alvo.kcal} kcal — registre a atividade em Treinar e ele sobe.`
+      : `Alvo de ${dia.alvo.kcal} kcal (base ${nutricao.compensacao.baseKcal} + gasto ${dia.gasto}).`
+  }));
+
+  raiz.append(barraDoDia(dia));
+
+  // A refeição da vez, em destaque e com as duas ações a um toque.
+  if (prox) raiz.append(cartaoProxima(prox, alimentos, ctx));
+
+  raiz.append(listaRefeicoes(dia, prox, alimentos, ctx));
+  raiz.append(avulsas(dia, alimentos, ctx));
+
+  raiz.append(h('button.btn.btn-secundario.mt-3', {
+    type: 'button',
+    onClick: () => abrirCompositor({ alimentos, ctx })
+  }, icone('lista'), 'Registrar algo fora do plano'));
+
+  raiz.append(blocoSuplementos(dia, nutricao, ctx));
+
+  // Só os avisos que mudam o que ele vai comer agora.
+  const relevantes = dia.orientacoes.filter((o) => o.nivel === 'critico' || o.nivel === 'atencao');
+  if (relevantes.length) {
+    raiz.append(secao('Atenção hoje', h('div.pilha-2', null, relevantes.map((o) => aviso(o)))));
+  }
+
+  const banco = bancoCalorico(dados, registro);
+  if (banco.saldo > 0) {
+    raiz.append(h('div.mt-3', null, aviso({
+      nivel: 'atencao',
+      titulo: `${banco.titulo}: ${banco.saldo} kcal a repor`,
+      texto: `${nutricao.compensacao.banco.nota} Detalhe em Consultar → Semana.`
+    })));
+  }
+
+  return raiz;
+}
+
+/* ===================== progresso do dia ===================== */
+
+/**
+ * Uma linha só, com o que ele precisa saber de cabeça: quanto falta de caloria
+ * e de proteína. Os quatro macros completos ficam na lista de refeições.
+ */
+function barraDoDia(dia) {
+  const item = (rotulo, feito, alvo, unidade, cor) => {
+    const falta = alvo - feito;
+    return h('div', null,
+      barraMacro(rotulo, feito, alvo, ` / ${alvo}`, cor),
+      h('p.texto-xs.texto-3', {
+        texto: falta > 0
+          ? `faltam ${falta}${unidade}`
+          : falta === 0 ? 'fechado' : `${-falta}${unidade} acima do alvo`
+      })
+    );
+  };
+
+  return h('div.card', { estilo: { '--accent': 'var(--c-nutricao)' } },
+    item('Calorias', dia.consumido.kcal, dia.alvo.kcal, ' kcal', 'var(--c-nutricao)'),
+    item('Proteína', dia.consumido.p, dia.alvo.p, ' g', 'var(--c-treino)'),
+    h('p.legenda.mt-2', { texto: 'Caloria e proteína são o que se acompanha de cabeça. Gordura é fixa e o carboidrato absorve o resto — o detalhe por macro está em cada refeição.' })
+  );
+}
+
+/* ===================== a refeição da vez ===================== */
+
+function cartaoProxima(r, alimentos, ctx) {
+  const { registro } = ctx;
+
+  return h('div.card.mt-3', { estilo: { '--accent': 'var(--c-hoje)' } },
+    h('div.linha', null,
+      h('span.chip', { dataset: { nivel: r.janelaAnabolica ? 'critico' : 'accent' } },
+        r.janelaAnabolica ? 'agora — janela de 30 min' : 'agora'),
+      h('span.esticar'),
+      h('span.texto-sm.texto-3', { texto: r.hora })
+    ),
+    h('h2.mt-2', { texto: r.nome }),
+    h('p.texto-2.mt-2', { texto: r.itens }),
+    h('p.legenda.mt-2', { texto: `${r.macros.kcal} kcal · P${r.macros.p} G${r.macros.g} C${r.macros.c}` }),
+
+    h('div.grade.grade-2.mt-3', null,
+      h('button.btn.btn-primario', {
+        type: 'button',
+        onClick: () => { registro.alternarRefeicao(r); toast('Registrado.'); ctx.recarregar(); }
+      }, icone('check'), 'Comi isso'),
+      h('button.btn.btn-secundario', {
+        type: 'button',
+        onClick: () => abrirCompositor({ alimentos, refeicao: r, ctx })
+      }, icone('editor'), 'Comi outra coisa')
+    ),
+
+    r.trocas && r.trocas.length
+      ? h('details.mt-3', null,
+          h('summary.legenda', { texto: 'Trocas equivalentes' }),
+          h('ul.lista.mt-2', null, r.trocas.map((t) => h('li', { texto: t })))
+        )
+      : null
+  );
+}
+
+/* ===================== as demais refeições ===================== */
+
+function listaRefeicoes(dia, prox, alimentos, ctx) {
+  const { registro } = ctx;
+  const restantes = dia.tipo.refeicoes.filter((r) => !prox || r.id !== prox.id);
+  const feitas = dia.tipo.refeicoes.length - dia.pendentes.length;
+
+  return secao(`Refeições do dia (${feitas}/${dia.tipo.refeicoes.length})`,
+    h('div.pilha-2', null, restantes.map((r) => {
+      const registrada = registro.refeicao(r.id);
+      const feita = Boolean(registrada);
+      const personalizada = Boolean(registrada && registrada.personalizada);
+      const itens = personalizada && registrada.composicao
+        ? descreverComposicao(alimentos, registrada.composicao)
+        : r.itens;
+      const m = personalizada ? registrada : r.macros;
+
+      return h('div.linha', null,
+        h('button.check-item.esticar', {
+          type: 'button', dataset: { feito: String(feita) },
+          onClick: () => { registro.alternarRefeicao(r); ctx.recarregar(); }
+        },
+          h('span.check-box', null, icone('check')),
+          h('span.check-texto', null,
+            h('strong', null, `${r.hora} · ${r.nome}`,
+              personalizada ? h('span', null, ' ', chip('personalizada', 'info')) : null),
+            h('span', { texto: itens }),
+            h('span.texto-xs', { texto: `${personalizada ? '' : '~'}${m.kcal} kcal · P${m.p} G${m.g} C${m.c}` })
+          )
+        ),
+        h('button.icon-btn', {
+          type: 'button', 'aria-label': `Personalizar ${r.nome}`, title: 'Comi outra coisa',
+          onClick: () => abrirCompositor({
+            alimentos, refeicao: r, ctx,
+            inicial: personalizada ? registrada.composicao : r.composicao
+          })
+        }, icone('editor'))
+      );
+    }))
+  );
+}
+
+/** Refeições registradas que não fazem parte do cardápio do dia. */
+function avulsas(dia, alimentos, ctx) {
+  const { registro } = ctx;
+  const doCardapio = new Set(dia.tipo.refeicoes.map((r) => r.id));
+  const extras = (registro.dia().refeicoes || []).filter((r) => !doCardapio.has(r.id));
+  if (!extras.length) return h('div');
+
+  return secao(`Fora do cardápio (${extras.length})`,
+    h('div.pilha-2', null, extras.map((r) => h('div.linha', null,
+      h('div.esticar', null,
+        h('strong.texto-sm', { texto: r.hora ? `${r.hora} · ${r.nome}` : r.nome }),
+        h('div.texto-xs.texto-3', {
+          texto: r.composicao ? descreverComposicao(alimentos, r.composicao) : '—'
+        }),
+        h('div.texto-xs', { texto: `${r.kcal} kcal · P${r.p} G${r.g} C${r.c}` })
+      ),
+      r.composicao
+        ? h('button.icon-btn', {
+            type: 'button', 'aria-label': `Editar ${r.nome}`, title: 'Editar',
+            onClick: () => abrirCompositor({
+              alimentos, ctx,
+              refeicao: { id: r.id, nome: r.nome, hora: r.hora, itens: '', composicao: r.composicao }
+            })
+          }, icone('editor'))
+        : null,
+      h('button.icon-btn', {
+        type: 'button', 'aria-label': `Remover ${r.nome}`, title: 'Remover',
+        onClick: () => { registro.removerRefeicao(r.id); toast('Removida.'); ctx.recarregar(); }
+      }, icone('lixeira'))
+    )))
+  );
+}
+
+/* ===================== suplementos ===================== */
+
+function blocoSuplementos(dia, nutricao, ctx) {
+  const { registro } = ctx;
+  const lista = suplementosDoDia(nutricao.suplementos, dia, nutricao.orientacoes);
+  if (!lista.length) return h('div');
+
+  const feitos = () => lista.filter((s) => registro.suplementoTomado(s.nome)).length;
+  const contador = h('span.chip', { dataset: { nivel: feitos() === lista.length ? 'ok' : 'accent' } },
+    `${feitos()}/${lista.length}`);
+
+  const itens = lista.map((s) => {
+    const item = h('button.check-item', {
+      type: 'button',
+      dataset: { feito: String(registro.suplementoTomado(s.nome)) },
+      onClick: () => {
+        item.dataset.feito = String(registro.alternarSuplemento(s.nome));
+        contador.textContent = `${feitos()}/${lista.length}`;
+        contador.dataset.nivel = feitos() === lista.length ? 'ok' : 'accent';
+      }
+    },
+      h('span.check-box', null, icone('check')),
+      h('span.check-texto', null,
+        h('strong', null, s.nome, ' ', h('span.texto-3.texto-sm', { texto: s.dose })),
+        h('span', { texto: s.quando })
+      ),
+      s.critico ? chip('obrigatório', 'critico') : null
+    );
+    return item;
+  });
+
+  return h('section.secao', null,
+    h('div.secao-cabecalho', null,
+      h('h2', null, icone('pilula'), ' Suplementos'),
+      contador
+    ),
+    h('div.mt-2', null, itens)
+  );
+}
+
+export { horaDaRefeicao };

--- a/app/views/consultar.js
+++ b/app/views/consultar.js
@@ -1,0 +1,87 @@
+// Aba "Consultar" — tudo que é referência, num lugar só.
+//
+// Separar consulta de operação é o que permite as abas Comer e Treinar serem
+// enxutas: o plano completo, os exames, os laudos e o balanço da semana são
+// coisas que se lê de vez em quando, não a cada abertura do app.
+
+import { h, icone, cabecalhoPagina, secao } from '../ui.js';
+
+const GRUPOS = [
+  {
+    titulo: 'O plano',
+    itens: [
+      { id: 'nutricao', nome: 'Nutrição', desc: 'Cardápio por tipo de dia, alimentos, compensação, estratégias e metas', icone: 'nutricao', cor: 'var(--c-nutricao)' },
+      { id: 'treino', nome: 'Série de musculação', desc: 'Sessões A a D, volume, progressão, restrições e rotação', icone: 'treino', cor: 'var(--c-treino)' },
+      { id: 'pedal', nome: 'Ciclismo', desc: 'Rotina, protocolo do joelho, resistência e cuidados', icone: 'pedal', cor: 'var(--c-pedal)' }
+    ]
+  },
+  {
+    titulo: 'Acompanhamento',
+    itens: [
+      { id: 'semana', nome: 'Últimos 7 dias', desc: 'O que foi feito, gasto e balanço calórico, volume por grupo', icone: 'historico', cor: 'var(--c-hoje)' },
+      { id: 'saude', nome: 'Saúde', desc: 'Resumo clínico, composição corporal, exames, laudos e pendências', icone: 'saude', cor: 'var(--c-saude)' },
+      { id: 'dermatologia', nome: 'Dermatologia', desc: 'Rotina de pele', icone: 'derma', cor: 'var(--c-derma)' }
+    ]
+  },
+  {
+    titulo: 'Registro e dados',
+    itens: [
+      { id: 'historico', nome: 'Histórico', desc: 'Mudanças de plano ao longo do tempo', icone: 'historico', cor: 'var(--c-geral)' },
+      { id: 'pareceres', nome: 'Pareceres', desc: 'Avaliações multidisciplinares', icone: 'parecer', cor: 'var(--c-geral)' },
+      { id: 'perfil', nome: 'Perfil', desc: 'Dados pessoais e agenda de referência', icone: 'perfil', cor: 'var(--c-geral)' },
+      { id: 'editor', nome: 'Editar dados', desc: 'Editar o JSON de um documento e baixar cifrado', icone: 'editor', cor: 'var(--c-geral)' }
+    ]
+  }
+];
+
+export async function render(ctx) {
+  const perfil = await ctx.store.doc('perfil');
+  const raiz = h('div');
+  raiz.append(cabecalhoPagina({
+    kicker: 'Referência',
+    titulo: 'Consultar',
+    subtitulo: 'O que não é do dia a dia. Para operar, use Comer e Treinar.'
+  }));
+
+  for (const g of GRUPOS) {
+    raiz.append(secao(g.titulo,
+      h('div.pilha-2', null, g.itens.map((i) => h('button.nav-card', {
+        type: 'button', estilo: { '--accent': i.cor },
+        onClick: () => ctx.navegar(`#/${i.id}`)
+      },
+        h('span.nav-card-icone', null, icone(i.icone)),
+        h('span.nav-card-texto', null,
+          h('strong', { texto: i.nome }),
+          h('span', { texto: i.desc })
+        ),
+        h('span.nav-card-seta', null, icone('seta'))
+      )))
+    ));
+  }
+
+  // Atalhos vindos do dado, só os que levam a uma sub-aba: os que apontam para
+  // a raiz de uma seção já estão nos grupos acima e virariam linha repetida.
+  const raizes = new Set(GRUPOS.flatMap((g) => g.itens.map((i) => `#/${i.id}`)));
+  const atalhos = (perfil.atalhos || []).filter((a) => !raizes.has(a.rota));
+  if (atalhos.length) {
+    raiz.append(secao('Ir direto',
+      h('div.grade.grade-2', null, atalhos.map((a) => h('button.nav-card', {
+        type: 'button', estilo: { '--accent': 'var(--c-geral)' },
+        onClick: () => ctx.navegar(a.rota)
+      },
+        h('span.nav-card-icone', null, icone(a.icone)),
+        h('span.nav-card-texto', null,
+          h('strong', { texto: a.titulo }),
+          h('span', { texto: a.descricao })
+        )
+      )))
+    ));
+  }
+
+  raiz.append(h('p.legenda.mt-4', null,
+    'Busca global no ícone de lupa ou ', h('kbd', { texto: 'Ctrl/Cmd + K' }),
+    ' — procura em todos os documentos decifrados.'
+  ));
+
+  return raiz;
+}

--- a/app/views/hoje.js
+++ b/app/views/hoje.js
@@ -1,17 +1,14 @@
-// Aba "Hoje" — registrar o que foi feito e ingerido, e ver a orientação
-// recalculada a partir disso.
+// Aba "Hoje" — triagem, não painel.
+//
+// O app é aberto com UMA intenção. Esta tela responde "o que faço agora?" e
+// oferece os cinco atalhos que cobrem os momentos frequentes: saber o que
+// comer, registrar o que comeu, saber a série, registrar a série, registrar o
+// pedal. Detalhe é nas abas Comer e Treinar; referência é em Consultar.
 
 import {
-  h, icone, cabecalhoPagina, aviso, chip, card, cartaoNavegacao,
-  barraMacro, dataLonga, dataCurta, secao, toast, nb
+  h, icone, cabecalhoPagina, aviso, dataLonga
 } from '../ui.js';
-import {
-  resumoDia, resumoJanela, suplementosDoDia,
-  gastoDaAtividade, bancoCalorico, formatarDuracao, descreverComposicao
-} from '../motor.js';
-import { abrirCompositor } from './compositor.js';
-
-const CORES_MACRO = { p: 'var(--c-nutricao)', g: 'var(--c-atencao)', c: 'var(--c-treino)' };
+import { resumoDia, resumoJanela, proximaAcao } from '../motor.js';
 
 export async function render(ctx) {
   const { store, registro } = ctx;
@@ -20,38 +17,18 @@ export async function render(ctx) {
 
   const dia = resumoDia(dados, registro);
   const jan = resumoJanela(dados, registro);
-  const banco = bancoCalorico(dados, registro);
+  const acao = proximaAcao(dados, dia, jan);
 
   const raiz = h('div');
   raiz.append(cabecalhoPagina({
     kicker: dataLonga(new Date()),
     titulo: saudacao(perfil.pessoa.primeiroNome),
-    subtitulo: resumoTexto(dia, jan)
+    subtitulo: statusDoDia(dia)
   }));
 
-  raiz.append(blocoRegistro(dia, jan, dados, ctx));
-
-  for (const o of dia.orientacoes.filter((x) => x.nivel !== 'info')) {
-    raiz.append(h('div.mt-2', null, aviso(o)));
-  }
-
-  raiz.append(blocoTreinoDoDia(dia, jan, ctx));
-  raiz.append(blocoNutricao(dia, banco, nutricao, ctx));
-  raiz.append(blocoSuplementos(dia, nutricao, ctx));
-
-  const infos = dia.orientacoes.filter((x) => x.nivel === 'info');
-  if (infos.length) {
-    raiz.append(secao('Lembretes do dia', h('div.pilha-2', null, infos.map((o) => aviso(o)))));
-  }
-
-  raiz.append(blocoJanela(jan, ctx));
-
-  const alertasPerfil = perfil.alertas || [];
-  if (alertasPerfil.length) {
-    raiz.append(secao('Atenção contínua', h('div.pilha-2', null, alertasPerfil.map(avisoNavegavel))));
-  }
-
-  raiz.append(secao('Consultar', h('div.grade.grade-2', null, (perfil.atalhos || []).map((a) => cartaoNavegacao(a)))));
+  raiz.append(cartaoAgora(acao, ctx));
+  raiz.append(atalhos(dia, jan, ctx));
+  raiz.append(alertas(dia, jan, perfil, ctx));
 
   return raiz;
 }
@@ -61,510 +38,133 @@ function saudacao(nome) {
   return `${hora < 12 ? 'Bom dia' : hora < 18 ? 'Boa tarde' : 'Boa noite'}, ${nome}`;
 }
 
-function resumoTexto(dia, jan) {
-  if (dia.provisorio) {
-    return `Nada registrado hoje. Na janela de ${jan.janelaDias} dias: ${jan.academias.length}/${jan.metaAcademia} academias · ${jan.pedais.length}/${jan.metaPedal} pedais.`;
-  }
-  const partes = dia.sessoes.map((s) => `Treino ${s.id}`);
-  if (dia.atividades.some((a) => a.tipo === 'pedal')) partes.push('pedal');
-  return `${partes.join(' + ')} · gasto ${dia.gasto} kcal · alvo ${dia.alvo.kcal} kcal · ${dia.consumido.kcal} kcal registradas`;
+/** Uma linha, três números: o que gastou, o alvo, o que já comeu. */
+function statusDoDia(dia) {
+  const partes = [];
+  if (dia.gasto) partes.push(`gasto ${dia.gasto} kcal`);
+  partes.push(`alvo ${dia.alvo.kcal} kcal`);
+  partes.push(`comeu ${dia.consumido.kcal}`);
+  if (dia.provisorio) partes.push('sem atividade registrada');
+  return partes.join(' · ');
 }
 
-/* ===================== registro de atividades ===================== */
+/* ===================== o que fazer agora ===================== */
 
-const DURACOES_PEDAL = [45, 60, 90, 120, 150, 180, 210, 240, 300];
-const DURACOES_ACADEMIA = [45, 60, 75, 90, 105];
+const COR_URGENCIA = {
+  critico: 'var(--c-critico)',
+  atencao: 'var(--c-atencao)',
+  info: 'var(--c-hoje)',
+  ok: 'var(--c-ok)'
+};
 
-function blocoRegistro(dia, jan, dados, ctx) {
-  const { registro } = ctx;
-  const { treinos, nutricao } = dados;
-  const comp = nutricao.compensacao;
-  const defPedal = comp.atividades.find((a) => a.id === 'pedal');
-
-  const registrar = (atividade) => {
-    registro.registrarAtividade(atividade);
-    ctx.recarregar();
-  };
-
-  const pedalFeito = dia.atividades.some((a) => a.tipo === 'pedal');
-  const sugerida = jan.proxima.escolhida;
-
-  /* --- pedal: perfil + duração, com o gasto estimado ao vivo --- */
-  const selPerfil = h('select', { 'aria-label': 'Intensidade do pedal' },
-    defPedal.perfis.map((p) => h('option', { value: p.id, selected: Boolean(p.padrao) }, p.nome))
-  );
-  const selDurPedal = h('select', { 'aria-label': 'Duração do pedal' },
-    DURACOES_PEDAL.map((m) => h('option', {
-      value: String(m), selected: m === defPedal.duracaoPadraoMin
-    }, formatarDuracao(m)))
-  );
-  const previaPedal = h('b.num');
-  const atualizarPrevia = () => {
-    const kcal = gastoDaAtividade(
-      { tipo: 'pedal', perfil: selPerfil.value, duracaoMin: Number(selDurPedal.value) }, comp);
-    previaPedal.textContent = `≈ ${kcal} kcal`;
-  };
-  selPerfil.addEventListener('change', atualizarPrevia);
-  selDurPedal.addEventListener('change', atualizarPrevia);
-  atualizarPrevia();
-
-  const botaoPedal = h('button.btn.btn-bloco.btn-primario', {
-    type: 'button',
-    estilo: { background: 'var(--c-pedal)' },
-    onClick: () => registrar({
-      tipo: 'pedal',
-      perfil: selPerfil.value,
-      duracaoMin: Number(selDurPedal.value),
-      zona: dados.pedal.plano.zona
-    })
-  }, icone('pedal'), pedalFeito ? 'Registrar outro pedal' : 'Pedalei');
-
-  /* --- academia: série + duração --- */
-  const seletorSessao = h('select', { 'aria-label': 'Qual série' },
-    treinos.sessoes.map((s) => h('option', {
-      value: s.id,
-      selected: sugerida && sugerida.sessao.id === s.id
-    }, `${s.id} — ${s.nome}`))
-  );
-  const selDurAcad = h('select', { 'aria-label': 'Duração do treino' },
-    DURACOES_ACADEMIA.map((m) => h('option', {
-      value: String(m),
-      selected: m === comp.atividades.find((a) => a.id === 'academia').duracaoPadraoMin
-    }, formatarDuracao(m)))
-  );
-
-  const botaoAcademia = h('button.btn.btn-bloco.btn-primario', {
-    type: 'button',
-    estilo: { background: 'var(--c-treino)' },
-    onClick: () => registrar({
-      tipo: 'academia', sessao: seletorSessao.value, duracaoMin: Number(selDurAcad.value)
-    })
-  }, icone('treino'), 'Malhei');
-
-  const feitasHoje = dia.atividades.length
-    ? h('div.mt-4', null,
-        h('p.legenda', { texto: 'Registrado hoje — toque no gasto para corrigir pelo ciclocomputador:' }),
-        h('div.pilha-2.mt-2', null, dia.atividades.map((a) => linhaAtividade(a, comp, treinos, ctx)))
-      )
-    : null;
-
-  return h('div.card', { estilo: { '--accent': 'var(--c-hoje)' } },
-    h('h2.card-titulo', null, icone('lista'), ' O que você fez hoje?'),
-    h('p.legenda', { texto: 'Registre a cada execução com a duração — o alvo do dia é a base de descanso mais o gasto do que entrar aqui.' }),
-
-    h('div.grade.grade-2.mt-3', null,
-      h('div.pilha-2', null,
-        h('div.linha', null, h('span.esticar', null, selPerfil)),
-        h('div.linha', null, h('span.esticar', null, selDurPedal), previaPedal),
-        botaoPedal
-      ),
-      h('div.pilha-2', null,
-        h('div.linha', null, h('span.esticar', null, seletorSessao)),
-        h('div.linha', null, h('span.esticar', null, selDurAcad),
-          h('b.num', { texto: `≈ ${gastoDaAtividade({ tipo: 'academia' }, comp)} kcal` })),
-        botaoAcademia
-      )
-    ),
-    feitasHoje
-  );
-}
-
-/**
- * Uma atividade registrada, com o gasto que ela gerou. O gasto é um campo
- * editável: se o ciclocomputador deu outro número, ele substitui a estimativa.
- */
-function linhaAtividade(a, comp, treinos, ctx) {
-  const { registro } = ctx;
-  const kcal = gastoDaAtividade(a, comp);
-  const medido = Number.isFinite(a.kcal);
-
-  const entrada = h('input', {
-    type: 'number', min: '0', step: '10', value: String(kcal),
-    'aria-label': 'Gasto em kcal',
-    estilo: { width: '6.5rem', textAlign: 'right' },
-    onChange: (e) => {
-      const v = Number(e.target.value);
-      registro.atualizarAtividade(a.id, { kcal: Number.isFinite(v) && v > 0 ? Math.round(v) : null });
-      toast(Number.isFinite(v) && v > 0 ? 'Gasto corrigido.' : 'Voltou para a estimativa.');
-      ctx.recarregar();
-    }
-  });
-
-  return h('div.linha', null,
-    chip(rotuloAtividade(a, treinos), a.tipo === 'academia' ? 'accent' : 'atencao',
-      a.tipo === 'academia' ? 'treino' : 'pedal'),
-    h('span.esticar'),
-    medido ? chip('medido', 'ok') : null,
-    entrada,
-    h('span.texto-xs.texto-3', { texto: 'kcal' }),
-    h('button.icon-btn', {
-      type: 'button', 'aria-label': 'Desfazer este registro', title: 'Desfazer',
-      onClick: () => { registro.removerAtividade(a.id); toast('Registro desfeito.'); ctx.recarregar(); }
-    }, icone('voltar'))
-  );
-}
-
-function rotuloAtividade(a, treinos) {
-  const dur = a.duracaoMin ? ` ${formatarDuracao(a.duracaoMin)}` : '';
-  if (a.tipo === 'pedal') return `Pedal ${a.perfil || 'z2'}${dur}`;
-  if (a.tipo !== 'academia') return `${a.tipo}${dur}`; // registro antigo de um tipo removido
-  const s = treinos.sessoes.find((x) => x.id === a.sessao);
-  return s ? `Treino ${s.id}${dur}` : `Treino ${a.sessao}${dur}`;
-}
-
-/* ===================== treino ===================== */
-
-function blocoTreinoDoDia(dia, jan, ctx) {
-  const { registro } = ctx;
-
-  // Já treinou hoje: mostra progresso das séries.
-  if (dia.sessoes.length) {
-    return h('div.pilha.mt-3', null, dia.sessoes.map((s) => {
-      const prog = registro.progressoSessao(s);
-      return h('div.card', { estilo: { '--accent': 'var(--c-treino)' } },
-        h('div.linha', null,
-          h('span.nav-card-icone', null, icone('treino')),
-          h('div.esticar', null,
-            h('h3', { texto: `Treino ${s.id} — ${s.nome}` }),
-            h('p.legenda', { texto: s.foco.join(' · ') })
-          )
-        ),
-        h('div.linha.mt-3', null,
-          h('span.barra.esticar', { estilo: { '--barra-c': 'var(--c-ok)' } },
-            h('i', { estilo: { width: prog.perc + '%' } })),
-          h('b.texto-sm.num', { texto: `${prog.feitas}/${prog.total}` })
-        ),
-        h('button.btn.btn-fantasma.mt-3', {
-          type: 'button', estilo: { '--accent': 'var(--c-treino)' },
-          onClick: () => ctx.navegar(`#/treino/${s.id}`)
-        }, 'Abrir a série', icone('seta'))
-      );
-    }));
-  }
-
-  // Ainda não treinou: sugere a próxima.
-  const p = jan.proxima;
-  if (!p.escolhida) {
-    return h('div.mt-3', null, aviso({
-      nivel: 'ok',
-      titulo: 'Nenhuma sessão liberada agora',
-      texto: 'Todas as opções estão bloqueadas por limite clínico ou intervalo de recuperação. Hoje é dia de pedal leve ou descanso.'
-    }));
-  }
-
-  const s = p.escolhida.sessao;
-  const motivos = p.escolhida.bloqueios;
-
-  return h('div.card.mt-3', { estilo: { '--accent': 'var(--c-treino)' } },
+function cartaoAgora(a, ctx) {
+  return h('div.card', { estilo: { '--accent': COR_URGENCIA[a.urgencia] } },
     h('div.linha', null,
-      h('span.nav-card-icone', null, icone('treino')),
-      h('div.esticar', null,
-        h('h3', { texto: `Próxima sugerida: ${s.id} — ${s.nome}` }),
-        h('p.legenda', { texto: s.foco.join(' · ') })
-      )
+      h('span.chip', { dataset: { nivel: a.urgencia === 'info' ? 'accent' : a.urgencia } }, 'agora'),
+      h('span.esticar')
     ),
-    h('div.chip-linha.mt-3', null,
-      chip(`${s.exercicios.reduce((a, e) => a + e.series, 0)} séries`, 'accent'),
-      chip(`~${s.duracaoMin} min`, null, 'relogio'),
-      chip(p.escolhida.categoria)
-    ),
-    jan.pendencia.completa && h('p.legenda.mt-3', {
-      texto: `As 4 sessões já foram feitas na janela de ${jan.janelaDias} dias — esta é a reabertura do ciclo.`
-    }),
-    motivos.length ? h('p.legenda.mt-2', { texto: 'Ressalva: ' + motivos.map((b) => b.texto).join('; ') + '.' }) : null,
-    h('div.grade.grade-2.mt-3', null,
-      h('button.btn.btn-primario', {
-        type: 'button', estilo: { background: 'var(--c-treino)' },
-        onClick: () => { registro.registrarAtividade({ tipo: 'academia', sessao: s.id }); ctx.recarregar(); }
-      }, icone('check'), `Registrar ${s.id}`),
-      h('button.btn.btn-secundario', {
-        type: 'button', onClick: () => ctx.navegar(`#/treino/${s.id}`)
-      }, 'Ver a série', icone('seta'))
-    )
-  );
-}
-
-/* ===================== nutrição ===================== */
-
-function blocoNutricao(dia, banco, nutricao, ctx) {
-  const { registro } = ctx;
-  const comp = nutricao.compensacao;
-  const alimentos = nutricao.alimentos;
-  const t = dia.tipo;
-  const alvo = dia.alvo;
-
-  const marcar = (r) => { registro.alternarRefeicao(r); ctx.recarregar(); };
-
-  const linhaRestante = (rotulo, valor, unidade) => h('div.def-linha', null,
-    h('dt', { texto: rotulo }),
-    h('dd', {
-      estilo: { color: valor < 0 ? 'var(--c-critico)' : valor === 0 ? 'var(--c-ok)' : 'inherit' },
-      texto: `${valor > 0 ? 'faltam ' : valor < 0 ? 'excedeu ' : ''}${Math.abs(valor)}${unidade}`
-    })
-  );
-
-  return h('div.card.mt-3', { estilo: { '--accent': 'var(--c-nutricao)' } },
-    h('div.linha', null,
-      h('span.nav-card-icone', null, icone('nutricao')),
-      h('div.esticar', null,
-        h('h3', { texto: `${t.nome} · alvo ${alvo.kcal} kcal` }),
-        h('p.legenda', {
-          texto: dia.provisorio
-            ? 'Alvo provisório de descanso — sobe se você registrar uma atividade.'
-            : `Derivado do que você registrou hoje.`
-        })
-      ),
-      h('button.icon-btn', {
-        type: 'button', 'aria-label': 'Abrir nutrição', onClick: () => ctx.navegar(`#/nutricao/${t.id}`)
-      }, icone('seta'))
-    ),
-
-    // De onde vem o número: base de um dia parado + o gasto registrado.
-    blocoContaDoAlvo(dia, comp),
-
-    h('div.mt-3', null,
-      barraMacro('Calorias', dia.consumido.kcal, alvo.kcal, ` / ${alvo.kcal}`, 'var(--c-nutricao)'),
-      barraMacro('Proteína', dia.consumido.p, alvo.p, ` / ${alvo.p} g`, CORES_MACRO.p),
-      barraMacro('Gordura', dia.consumido.g, alvo.g, ` / ${alvo.g} g`, CORES_MACRO.g),
-      barraMacro('Carboidrato', dia.consumido.c, alvo.c, ` / ${alvo.c} g`, CORES_MACRO.c)
-    ),
-
-    h('h4.mt-4', { texto: 'Falta ingerir' }),
-    h('dl.def.mt-2', null,
-      linhaRestante('Calorias', dia.restante.kcal, ' kcal'),
-      linhaRestante('Proteína', dia.restante.p, ' g'),
-      linhaRestante('Carboidrato', dia.restante.c, ' g')
-    ),
-
-    // O reforço do cardápio e o corte pelo teto já saem em dia.orientacoes,
-    // renderizadas no topo da página — aqui só o banco, que o motor não avisa.
-    banco.saldo > 0 ? blocoBanco(banco, comp) : null,
-
-    h('h4.mt-4', { texto: `Refeições (${t.refeicoes.length - dia.pendentes.length}/${t.refeicoes.length})` }),
-    h('div.mt-2', null, t.refeicoes.map((r) => linhaRefeicaoDoDia(r, alimentos, ctx))),
-
-    // Refeições que não estão no cardápio do dia (avulsas ou de outro tipo).
-    avulsas(dia, t, alimentos, ctx),
-
-    h('button.btn.btn-fantasma.mt-3', {
+    h('h2.mt-2', { texto: a.titulo }),
+    h('p.texto-2.mt-2', { texto: a.texto }),
+    h('button.btn.btn-bloco.btn-primario.mt-3', {
       type: 'button',
-      onClick: () => abrirCompositor({ alimentos, ctx })
-    }, icone('lista'), 'Registrar outra refeição'),
-
-    h('p.legenda.mt-3', { texto: 'Marque para comer como no plano, ou toque no lápis para dizer o que realmente comeu — os macros passam a ser os do que você montou.' })
+      estilo: { background: COR_URGENCIA[a.urgencia] },
+      onClick: () => ctx.navegar(a.rota)
+    }, a.acao, icone('seta'))
   );
 }
 
-/**
- * Uma refeição do cardápio: marcar como feita (macros do plano) ou personalizar
- * (macros do que foi montado). Quando personalizada, mostra o que foi comido em
- * vez do que estava planejado.
- */
-function linhaRefeicaoDoDia(r, alimentos, ctx) {
-  const { registro } = ctx;
-  const registrada = registro.refeicao(r.id);
-  const feita = Boolean(registrada);
-  const personalizada = Boolean(registrada && registrada.personalizada);
+/* ===================== os cinco momentos ===================== */
 
-  const itens = personalizada && registrada.composicao
-    ? descreverComposicao(alimentos, registrada.composicao)
-    : r.itens;
-  const m = personalizada ? registrada : r.macros;
+function atalhos(dia, jan, ctx) {
+  const feitas = dia.tipo.refeicoes.length - dia.pendentes.length;
+  const total = dia.tipo.refeicoes.length;
+  const serie = dia.sessoes.length
+    ? dia.sessoes.map((s) => s.id).join(' + ')
+    : jan.proxima.escolhida ? jan.proxima.escolhida.sessao.id : '—';
 
-  return h('div.linha', null,
-    h('button.check-item.esticar', {
-      type: 'button', dataset: { feito: String(feita) },
-      onClick: () => { registro.alternarRefeicao(r); ctx.recarregar(); }
-    },
-      h('span.check-box', null, icone('check')),
-      h('span.check-texto', null,
-        h('strong', null, `${r.hora} · ${r.nome}`,
-          r.tag ? h('span', null, ' ', chip(r.tag, 'accent')) : null,
-          r.combustivel ? h('span', null, ' ', chip('combustível', 'atencao')) : null,
-          personalizada ? h('span', null, ' ', chip('personalizada', 'info')) : null),
-        h('span', { texto: itens }),
-        h('span.texto-xs', { texto: `${personalizada ? '' : '~'}${m.kcal} kcal · P${m.p} G${m.g} C${m.c}` })
-      )
+  const tile = ({ titulo, nota, nomeIcone, cor, rota }) => h('button.nav-card', {
+    type: 'button', estilo: { '--accent': cor },
+    onClick: () => ctx.navegar(rota)
+  },
+    h('span.nav-card-icone', null, icone(nomeIcone)),
+    h('span.nav-card-texto', null,
+      h('strong', { texto: titulo }),
+      h('span', { texto: nota })
     ),
-    h('button.icon-btn', {
-      type: 'button', 'aria-label': `Personalizar ${r.nome}`, title: 'Dizer o que realmente comeu',
-      onClick: () => abrirCompositor({
-        alimentos, refeicao: r, ctx,
-        inicial: personalizada ? registrada.composicao : r.composicao
-      })
-    }, icone('editor'))
-  );
-}
-
-/** Refeições registradas que não fazem parte do cardápio do dia. */
-function avulsas(dia, tipo, alimentos, ctx) {
-  const { registro } = ctx;
-  const doCardapio = new Set(tipo.refeicoes.map((r) => r.id));
-  const extras = (registro.dia().refeicoes || []).filter((r) => !doCardapio.has(r.id));
-  if (!extras.length) return null;
-
-  return h('div.mt-3', null,
-    h('h4', { texto: `Fora do cardápio (${extras.length})` }),
-    h('div.pilha-2.mt-2', null, extras.map((r) => h('div.linha', null,
-      h('div.esticar', null,
-        h('strong.texto-sm', null, r.hora ? `${r.hora} · ${r.nome}` : r.nome),
-        h('div.texto-xs.texto-3', {
-          texto: r.composicao ? descreverComposicao(alimentos, r.composicao) : '—'
-        }),
-        h('div.texto-xs', { texto: `${r.kcal} kcal · P${r.p} G${r.g} C${r.c}` })
-      ),
-      r.composicao
-        ? h('button.icon-btn', {
-            type: 'button', 'aria-label': `Editar ${r.nome}`, title: 'Editar',
-            onClick: () => abrirCompositor({
-              alimentos, ctx,
-              refeicao: { id: r.id, nome: r.nome, hora: r.hora, itens: '', composicao: r.composicao }
-            })
-          }, icone('editor'))
-        : null,
-      h('button.icon-btn', {
-        type: 'button', 'aria-label': `Remover ${r.nome}`, title: 'Remover',
-        onClick: () => { registro.removerRefeicao(r.id); toast('Refeição removida.'); ctx.recarregar(); }
-      }, icone('voltar'))
-    )))
-  );
-}
-
-/**
- * A conta que produziu o alvo. Sem isso o número aparece do nada e não dá para
- * conferir contra o ciclocomputador.
- */
-function blocoContaDoAlvo(dia, comp) {
-  const d = dia.derivado;
-  const parcela = (rotulo, valor, cor) => h('div.metrica', { estilo: cor ? { '--accent': cor } : {} },
-    h('div.metrica-label', { texto: rotulo }),
-    h('div.metrica-valor', null, h('b.num', { texto: String(valor) })),
-    h('div.metrica-nota', { texto: 'kcal' })
+    h('span.nav-card-seta', null, icone('seta'))
   );
 
-  return h('div.mt-3', null,
-    h('div.grade.grade-3', null,
-      parcela('Base (dia parado)', comp.baseKcal),
-      parcela('Gasto registrado', d.gasto, 'var(--c-pedal)'),
-      parcela(d.noTeto ? `Alvo (teto ${comp.tetoKcalDia})` : 'Alvo de hoje', d.kcal, 'var(--c-nutricao)')
-    ),
-    h('p.legenda.mt-2', {
-      texto: `Proteína (${comp.proteinaFixaG} g) e gordura (${comp.gorduraFixaG} g) são fixas — todo o gasto vira carboidrato: ${comp.baseCarboG} g de base + ${Math.round((d.kcal - comp.baseKcal) / 4)} g do gasto.`
+  return h('div.pilha-2.mt-3', null,
+    tile({
+      titulo: 'O que comer',
+      nota: `${feitas}/${total} refeições · faltam ${Math.max(0, dia.restante.kcal)} kcal e ${Math.max(0, dia.restante.p)} g de proteína`,
+      nomeIcone: 'nutricao', cor: 'var(--c-nutricao)', rota: '#/comer'
+    }),
+    tile({
+      titulo: dia.sessoes.length ? `Série de hoje — ${serie}` : `Qual série fazer — ${serie}`,
+      nota: dia.sessoes.length
+        ? 'marcar série por série'
+        : `${jan.academias.length}/${jan.metaAcademia} na janela de ${jan.janelaDias} dias`,
+      nomeIcone: 'treino', cor: 'var(--c-treino)', rota: '#/treinar'
+    }),
+    tile({
+      titulo: 'Registrar pedal',
+      nota: dia.atividades.some((a) => a.tipo === 'pedal')
+        ? 'pedal já registrado hoje'
+        : `${jan.pedais.length}/${jan.metaPedal} na janela de ${jan.janelaDias} dias`,
+      nomeIcone: 'pedal', cor: 'var(--c-pedal)', rota: '#/treinar'
+    }),
+    tile({
+      titulo: 'Consultar',
+      nota: 'plano, exames, laudos, histórico e a semana',
+      nomeIcone: 'lista', cor: 'var(--c-geral)', rota: '#/consultar'
     })
   );
 }
 
-/** Saldo a repor nos próximos dias, quando o teto cortou parte do gasto. */
-function blocoBanco(banco, comp) {
-  return h('div.card.mt-3', { estilo: { '--accent': 'var(--c-atencao)' } },
-    h('div.linha', null,
-      h('span.nav-card-icone', null, icone('historico')),
-      h('div.esticar', null,
-        h('h4', { texto: `${banco.titulo}: ${banco.saldo} kcal a repor` }),
-        h('p.legenda', { texto: `Gerado ${banco.gerado} kcal · já reposto ${banco.reposto} kcal · janela de ${banco.janelaDias} dias.` })
-      )
-    ),
-    h('p.legenda.mt-2', { texto: banco.descricao }),
-    banco.detalhe.length
-      ? h('div.chip-linha.mt-2', null, banco.detalhe.map((x) => chip(
-          `${dataCurta(x.data)}: gasto ${x.gasto}${x.cortado ? ` · ${x.cortado} pendentes` : ''}${x.acimaDoAlvo ? ` · ${x.acimaDoAlvo} repostas` : ''}`,
-          x.cortado > x.acimaDoAlvo ? 'atencao' : 'ok'
-        )))
-      : null,
-    h('p.legenda.mt-2', { texto: comp.banco.nota })
-  );
-}
+/* ===================== alertas, com teto ===================== */
 
-/* ===================== suplementos ===================== */
+/**
+ * Só o mais urgente fica visível. O resto vai para um contador que abre a lista
+ * completa — sem isso a tela volta a ser uma parede de avisos.
+ */
+function alertas(dia, jan, perfil, ctx) {
+  const doDia = dia.orientacoes.filter((o) => o.nivel === 'critico' || o.nivel === 'atencao');
+  const daJanela = jan.alertas || [];
+  const continuos = perfil.alertas || [];
 
-function blocoSuplementos(dia, nutricao, ctx) {
-  const { registro } = ctx;
-  const lista = suplementosDoDia(nutricao.suplementos, dia, nutricao.orientacoes);
-  if (!lista.length) return h('div');
+  const todos = [...doDia, ...daJanela, ...continuos];
+  if (!todos.length) return h('div');
 
-  const feitos = () => lista.filter((s) => registro.suplementoTomado(s.nome)).length;
-  const contador = h('span.chip', { dataset: { nivel: feitos() === lista.length ? 'ok' : 'accent' } },
-    `${feitos()}/${lista.length}`);
+  const primeiro = doDia[0] || daJanela[0] || null;
+  const resto = todos.length - (primeiro ? 1 : 0);
 
-  const itens = lista.map((s) => {
-    const item = h('button.check-item', {
+  const frag = h('div.mt-3');
+  if (primeiro) frag.append(aviso(primeiro));
+
+  if (resto > 0) {
+    frag.append(h('button.btn.btn-fantasma.mt-2', {
       type: 'button',
-      dataset: { feito: String(registro.suplementoTomado(s.nome)) },
-      onClick: () => {
-        item.dataset.feito = String(registro.alternarSuplemento(s.nome));
-        contador.textContent = `${feitos()}/${lista.length}`;
-        contador.dataset.nivel = feitos() === lista.length ? 'ok' : 'accent';
-      }
-    },
-      h('span.check-box', null, icone('check')),
-      h('span.check-texto', null,
-        h('strong', null, s.nome, ' ', h('span.texto-3.texto-sm', { texto: s.dose })),
-        h('span', { texto: s.quando })
-      ),
-      s.critico ? chip('obrigatório', 'critico') : null
-    );
-    return item;
-  });
-
-  return h('section.secao', null,
-    h('div.secao-cabecalho', null,
-      h('h2', null, icone('pilula'), ' Suplementos de hoje'),
-      contador
-    ),
-    h('p.legenda', {
-      texto: dia.sessoes.length
-        ? 'Lista já ajustada ao treino registrado hoje.'
-        : 'Só os de uso diário — registrar um treino acrescenta whey, caseína e (em B/D) colágeno.'
-    }),
-    h('div.mt-2', null, itens)
-  );
-}
-
-/* ===================== janela móvel ===================== */
-
-function blocoJanela(jan, ctx) {
-  const anelPedal = `${jan.pedais.length}/${jan.metaPedal}`;
-  const anelAcad = `${jan.academias.length}/${jan.metaAcademia}`;
-
-  return h('section.secao', null,
-    h('div.secao-cabecalho', null,
-      h('h2', null, icone('historico'), ` Últimos ${jan.janelaDias} dias`),
-      h('button.btn.btn-fantasma', { type: 'button', onClick: () => ctx.navegar('#/semana') }, 'Detalhes', icone('seta'))
-    ),
-    h('div.grade.grade-2', null,
-      h('div.metrica', { dataset: { nivel: jan.faltamAcademia ? 'atencao' : 'ok' } },
-        h('div.metrica-label', { texto: 'Academia' }),
-        h('div.metrica-valor', null, h('b', { texto: anelAcad })),
-        h('div.metrica-nota', { texto: jan.faltamAcademia ? `faltam ${jan.faltamAcademia}` : 'meta batida' })
-      ),
-      h('div.metrica', { dataset: { nivel: jan.faltamPedal ? 'atencao' : 'ok' } },
-        h('div.metrica-label', { texto: 'Pedal' }),
-        h('div.metrica-valor', null, h('b', { texto: anelPedal })),
-        h('div.metrica-nota', { texto: jan.faltamPedal ? `faltam ${jan.faltamPedal}` : 'meta batida' })
-      ),
-    ),
-    jan.alertas.length
-      ? h('div.pilha-2.mt-3', null, jan.alertas.map((a) => aviso(a)))
-      : null,
-    !jan.pendencia.completa
-      ? h('p.legenda.mt-3', { texto: `Faltam nesta janela, em ordem de prioridade: ${jan.pendencia.restantes.join(', ')}.` })
-      : null
-  );
-}
-
-/* ===================== auxiliares ===================== */
-
-function avisoNavegavel(a) {
-  const el = aviso({ nivel: a.nivel, titulo: a.titulo, texto: a.texto, data: a.desde });
-  if (a.link) {
-    el.style.cursor = 'pointer';
-    el.setAttribute('role', 'button');
-    el.tabIndex = 0;
-    const ir = () => { location.hash = a.link; };
-    el.addEventListener('click', ir);
-    el.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); ir(); }
-    });
+      onClick: () => ctx.abrirSheet(h('div', null,
+        h('p.sheet-titulo', { texto: 'Do dia' }),
+        doDia.length
+          ? h('div.pilha-2', null, doDia.map((o) => aviso(o)))
+          : h('p.legenda', { texto: 'Nada pendente hoje.' }),
+        daJanela.length
+          ? h('div', null,
+              h('p.sheet-titulo', { texto: `Janela de ${jan.janelaDias} dias` }),
+              h('div.pilha-2', null, daJanela.map((a) => aviso(a)))
+            )
+          : null,
+        h('p.sheet-titulo', { texto: 'Atenção contínua' }),
+        continuos.length
+          ? h('div.pilha-2', null, continuos.map((a) => aviso({
+              nivel: a.nivel, titulo: a.titulo, texto: a.texto, data: a.desde
+            })))
+          : h('p.legenda', { texto: 'Nenhum alerta clínico aberto.' })
+      ), 'Alertas')
+    }, icone('alerta'), `Ver todos os alertas (${todos.length})`));
   }
-  return el;
+
+  return frag;
 }

--- a/app/views/treinar.js
+++ b/app/views/treinar.js
@@ -1,0 +1,221 @@
+// Aba "Treinar" — responde a três perguntas e nada mais:
+//   1. qual série eu tenho que fazer hoje?
+//   2. como eu registro a série que fiz?
+//   3. como eu registro o pedal que fiz?
+//
+// Se já há série registrada hoje, a página ABRE nela: na academia o que importa
+// é a lista de exercícios, não um painel. Volume, limites clínicos e a janela de
+// 7 dias ficam em Consultar → Treino e Consultar → Semana.
+
+import {
+  h, icone, cabecalhoPagina, aviso, chip, secao, toast, dataLonga
+} from '../ui.js';
+import {
+  resumoDia, resumoJanela, gastoDaAtividade, formatarDuracao
+} from '../motor.js';
+import { telaSessao } from './treino.js';
+
+const DURACOES_PEDAL = [45, 60, 90, 120, 150, 180, 210, 240, 300];
+const DURACOES_ACADEMIA = [45, 60, 75, 90, 105];
+
+export async function render(ctx) {
+  const { store, registro } = ctx;
+  const [perfil, treinos, nutricao, pedal] = await store.docs('perfil', 'treinos', 'nutricao', 'pedal');
+  const dados = { perfil, treinos, nutricao, pedal };
+
+  const dia = resumoDia(dados, registro);
+  const jan = resumoJanela(dados, registro);
+  const comp = nutricao.compensacao;
+
+  // Já treinou: a página é a série. Nada antes dela.
+  if (dia.sessoes.length) {
+    const raiz = h('div');
+    for (const s of dia.sessoes) {
+      raiz.append(telaSessao(s, treinos, jan, ctx, { voltar: false, volume: false }));
+    }
+    raiz.append(registrado(dia, comp, treinos, ctx));
+    raiz.append(blocoPedal(dia, dados, comp, ctx));
+    return raiz;
+  }
+
+  const raiz = h('div');
+  raiz.append(cabecalhoPagina({
+    kicker: dataLonga(new Date()),
+    titulo: 'Treinar',
+    subtitulo: `${jan.academias.length}/${jan.metaAcademia} academias e ${jan.pedais.length}/${jan.metaPedal} pedais nos últimos ${jan.janelaDias} dias.`
+  }));
+
+  raiz.append(blocoSerie(dia, jan, comp, ctx));
+  raiz.append(blocoPedal(dia, dados, comp, ctx));
+  if (dia.atividades.length) raiz.append(registrado(dia, comp, treinos, ctx));
+
+  return raiz;
+}
+
+/* ===================== a série de hoje ===================== */
+
+function blocoSerie(dia, jan, comp, ctx) {
+  const { registro } = ctx;
+  const p = jan.proxima.escolhida;
+
+  if (!p) {
+    return h('div', null, aviso({
+      nivel: 'ok',
+      titulo: 'Nenhuma série liberada agora',
+      texto: 'Todas as opções estão bloqueadas por limite clínico ou intervalo de recuperação. Hoje é pedal leve ou descanso.'
+    }));
+  }
+
+  const s = p.sessao;
+  const selDur = h('select', { 'aria-label': 'Duração do treino' },
+    DURACOES_ACADEMIA.map((m) => h('option', {
+      value: String(m),
+      selected: m === comp.atividades.find((a) => a.id === 'academia').duracaoPadraoMin
+    }, formatarDuracao(m)))
+  );
+  const seletorSessao = h('select', { 'aria-label': 'Qual série' },
+    jan.proxima.candidatos.map((c) => h('option',
+      { value: c.sessao.id, selected: c.sessao.id === s.id },
+      `${c.sessao.id} — ${c.sessao.nome}${c.livre ? '' : ' (com ressalva)'}`))
+  );
+
+  return h('div.card', { estilo: { '--accent': 'var(--c-treino)' } },
+    h('div.linha', null,
+      h('span.chip', { dataset: { nivel: 'accent' } }, 'sugerida agora'),
+      h('span.esticar'),
+      h('span.texto-sm.texto-3', { texto: `~${s.duracaoMin} min` })
+    ),
+    h('h2.mt-2', { texto: `Treino ${s.id} — ${s.nome}` }),
+    h('p.texto-2.mt-2', { texto: s.foco.join(' · ') }),
+    h('div.chip-linha.mt-2', null,
+      chip(`${s.exercicios.reduce((a, e) => a + e.series, 0)} séries`),
+      chip(`${s.exercicios.length} exercícios`),
+      p.bloqueios.length ? chip('com ressalva', 'atencao') : null
+    ),
+    p.bloqueios.length
+      ? h('p.legenda.mt-2', { texto: 'Ressalva: ' + p.bloqueios.map((b) => b.texto).join('; ') + '.' })
+      : null,
+
+    h('button.btn.btn-bloco.btn-primario.mt-3', {
+      type: 'button', estilo: { background: 'var(--c-treino)' },
+      onClick: () => {
+        registro.registrarAtividade({ tipo: 'academia', sessao: s.id, duracaoMin: Number(selDur.value) });
+        ctx.recarregar();
+      }
+    }, icone('check'), `Começar o treino ${s.id}`),
+    h('p.legenda.mt-2', { texto: 'Registra a sessão e abre a lista de exercícios para marcar série por série.' }),
+
+    h('details.mt-3', null,
+      h('summary.legenda', { texto: 'Outra série, ou outra duração' }),
+      h('div.pilha-2.mt-2', null,
+        h('div.linha', null, h('span.esticar', null, seletorSessao)),
+        h('div.linha', null,
+          h('span.esticar', null, selDur),
+          h('b.num', { texto: `≈ ${gastoDaAtividade({ tipo: 'academia' }, comp)} kcal` })
+        ),
+        h('button.btn.btn-secundario', {
+          type: 'button',
+          onClick: () => {
+            registro.registrarAtividade({
+              tipo: 'academia', sessao: seletorSessao.value, duracaoMin: Number(selDur.value)
+            });
+            ctx.recarregar();
+          }
+        }, icone('check'), 'Registrar essa')
+      )
+    )
+  );
+}
+
+/* ===================== pedal ===================== */
+
+function blocoPedal(dia, dados, comp, ctx) {
+  const { registro } = ctx;
+  const def = comp.atividades.find((a) => a.id === 'pedal');
+  const pedalFeito = dia.atividades.some((a) => a.tipo === 'pedal');
+
+  const selPerfil = h('select', { 'aria-label': 'Intensidade do pedal' },
+    def.perfis.map((p) => h('option', { value: p.id, selected: Boolean(p.padrao) }, p.nome))
+  );
+  const selDur = h('select', { 'aria-label': 'Duração do pedal' },
+    DURACOES_PEDAL.map((m) => h('option', {
+      value: String(m), selected: m === def.duracaoPadraoMin
+    }, formatarDuracao(m)))
+  );
+  const previa = h('b.num');
+  const atualizar = () => {
+    previa.textContent = `≈ ${gastoDaAtividade(
+      { tipo: 'pedal', perfil: selPerfil.value, duracaoMin: Number(selDur.value) }, comp)} kcal`;
+  };
+  selPerfil.addEventListener('change', atualizar);
+  selDur.addEventListener('change', atualizar);
+  atualizar();
+
+  return h('div.card.mt-3', { estilo: { '--accent': 'var(--c-pedal)' } },
+    h('h2.card-titulo', null, icone('pedal'), pedalFeito ? ' Outro pedal' : ' Pedalei'),
+    h('p.legenda', { texto: 'Duração e intensidade definem o gasto — e o gasto define quanto você precisa comer hoje.' }),
+    h('div.pilha-2.mt-3', null,
+      h('div.linha', null, h('span.esticar', null, selPerfil)),
+      h('div.linha', null, h('span.esticar', null, selDur), previa),
+      h('button.btn.btn-bloco.btn-primario', {
+        type: 'button', estilo: { background: 'var(--c-pedal)' },
+        onClick: () => {
+          registro.registrarAtividade({
+            tipo: 'pedal',
+            perfil: selPerfil.value,
+            duracaoMin: Number(selDur.value),
+            zona: dados.pedal.plano.zona
+          });
+          toast('Pedal registrado.');
+          ctx.recarregar();
+        }
+      }, icone('check'), 'Registrar pedal')
+    )
+  );
+}
+
+/* ===================== o que já entrou hoje ===================== */
+
+function registrado(dia, comp, treinos, ctx) {
+  const { registro } = ctx;
+  if (!dia.atividades.length) return h('div');
+
+  return secao(`Registrado hoje · gasto ${dia.gasto} kcal`,
+    h('div.pilha-2', null, dia.atividades.map((a) => {
+      const kcal = gastoDaAtividade(a, comp);
+      const entrada = h('input', {
+        type: 'number', min: '0', step: '10', value: String(kcal),
+        'aria-label': 'Gasto em kcal',
+        estilo: { width: '6.5rem', textAlign: 'right' },
+        onChange: (e) => {
+          const v = Number(e.target.value);
+          registro.atualizarAtividade(a.id, { kcal: Number.isFinite(v) && v > 0 ? Math.round(v) : null });
+          toast(Number.isFinite(v) && v > 0 ? 'Gasto corrigido.' : 'Voltou para a estimativa.');
+          ctx.recarregar();
+        }
+      });
+
+      return h('div.linha', null,
+        chip(rotulo(a, treinos), a.tipo === 'academia' ? 'accent' : 'atencao',
+          a.tipo === 'academia' ? 'treino' : 'pedal'),
+        h('span.esticar'),
+        Number.isFinite(a.kcal) ? chip('medido', 'ok') : null,
+        entrada,
+        h('span.texto-xs.texto-3', { texto: 'kcal' }),
+        h('button.icon-btn', {
+          type: 'button', 'aria-label': 'Desfazer este registro', title: 'Desfazer',
+          onClick: () => { registro.removerAtividade(a.id); toast('Registro desfeito.'); ctx.recarregar(); }
+        }, icone('lixeira'))
+      );
+    })),
+    h('p.legenda.mt-2', { texto: 'O número é editável: se o ciclocomputador deu outro valor, ele substitui a estimativa.' })
+  );
+}
+
+function rotulo(a, treinos) {
+  const dur = a.duracaoMin ? ` ${formatarDuracao(a.duracaoMin)}` : '';
+  if (a.tipo === 'pedal') return `Pedal ${a.perfil || 'z2'}${dur}`;
+  if (a.tipo !== 'academia') return `${a.tipo}${dur}`;
+  const s = treinos.sessoes.find((x) => x.id === a.sessao);
+  return s ? `Treino ${s.id}${dur}` : `Treino ${a.sessao}${dur}`;
+}

--- a/app/views/treino.js
+++ b/app/views/treino.js
@@ -80,14 +80,16 @@ function abaSessoes(treinos, jan, ctx) {
 
 /* ===================== detalhe da sessão ===================== */
 
-function telaSessao(s, treinos, jan, ctx) {
+export function telaSessao(s, treinos, jan, ctx, opcoes = {}) {
   const { registro } = ctx;
   const vol = volumeSessao(s);
   const raiz = h('div');
 
-  raiz.append(h('button.btn.btn-fantasma', {
-    type: 'button', onClick: () => ctx.navegar('#/treino')
-  }, icone('voltar'), 'Todas as sessões'));
+  if (opcoes.voltar !== false) {
+    raiz.append(h('button.btn.btn-fantasma', {
+      type: 'button', onClick: () => ctx.navegar('#/treino')
+    }, icone('voltar'), 'Todas as sessões'));
+  }
 
   raiz.append(cabecalhoPagina({
     kicker: `${s.dia} · ~${s.duracaoMin} min`,
@@ -138,7 +140,7 @@ function telaSessao(s, treinos, jan, ctx) {
     s.exercicios.map((ex) => cartaoExercicio(ex, s, registro, atualizarProgresso))
   ));
 
-  raiz.append(secao('Volume da sessão',
+  if (opcoes.volume !== false) raiz.append(secao('Volume da sessão',
     card(
       barrasHorizontais(
         Object.entries(vol.porGrupo).sort((a, b) => b[1] - a[1]).map(([nome, valor]) => ({ nome, valor })),

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,10 @@
   "theme_color": "#0b1120",
   "lang": "pt-BR",
   "dir": "ltr",
-  "categories": ["health", "fitness"],
+  "categories": [
+    "health",
+    "fitness"
+  ],
   "icons": [
     {
       "src": "icon.svg",
@@ -26,8 +29,20 @@
     }
   ],
   "shortcuts": [
-    { "name": "Treino de hoje", "url": "./#/treino", "description": "Abre a série do dia" },
-    { "name": "Nutrição", "url": "./#/nutricao", "description": "Macros e refeições" },
-    { "name": "Composição corporal", "url": "./#/saude/composicao", "description": "Bioimpedância" }
+    {
+      "name": "O que comer",
+      "url": "./#/comer",
+      "description": "Cardápio do dia e registro das refeições"
+    },
+    {
+      "name": "Treinar",
+      "url": "./#/treinar",
+      "description": "Série de hoje e registro de pedal"
+    },
+    {
+      "name": "Consultar",
+      "url": "./#/consultar",
+      "description": "Plano, exames, laudos e a semana"
+    }
   ]
 }

--- a/sw.js
+++ b/sw.js
@@ -9,7 +9,7 @@
 // O cache guarda apenas ciphertext dos documentos — a chave nunca é cacheada
 // (fica no localStorage do dispositivo).
 
-const VERSAO = 'rotina-v10-2026-07-31';
+const VERSAO = 'rotina-v11-2026-07-31';
 const CACHE_SHELL = `${VERSAO}-shell`;
 const CACHE_DADOS = `${VERSAO}-dados`;
 
@@ -26,6 +26,9 @@ const SHELL = [
   './app/charts.js',
   './app/motor.js',
   './app/views/hoje.js',
+  './app/views/comer.js',
+  './app/views/treinar.js',
+  './app/views/consultar.js',
   './app/views/compositor.js',
   './app/views/semana.js',
   './app/views/treino.js',


### PR DESCRIPTION
As páginas acumulavam tudo. Hoje tinha dez seções — registro, orientações, treino, nutrição completa, suplementos, janela de 7 dias, alertas clínicos contínuos e atalhos de consulta — somando **mais de 10 000 px de altura** para quem abre o app com uma intenção só.

## A separação que faltava: operar × consultar

Duas naturezas de conteúdo que não podem disputar a mesma tela:

- **Operar** — o que se faz várias vezes por dia.
- **Consultar** — plano completo, exames, laudos, balanço da semana. Se lê de vez em quando.

Quatro abas, cada uma com um trabalho:

| Aba | Responde | Contém |
|---|---|---|
| **Hoje** | o que eu faço agora? | uma ação em destaque, quatro atalhos, no máximo um alerta |
| **Comer** | o que preciso comer? como registro? | progresso do dia, refeição da vez, cardápio, suplementos |
| **Treinar** | qual série? como registro série e pedal? | série de hoje (ou a sugerida), registro de pedal, o que já entrou |
| **Consultar** | onde está aquilo? | todo o resto, agrupado |

## Os cinco momentos, e onde cada um resolve

O desenho partiu dos momentos de uso, não das entidades do domínio:

| Momento | Caminho | Toques |
|---|---|---|
| saber o que preciso comer | Comer → refeição da vez em destaque | 1 |
| registrar o que comi | Comer → **Comi isso**, ou **Comi outra coisa** para compor | 2 |
| saber qual série tenho que fazer | Treinar → série sugerida no topo | 1 |
| registrar a série que fiz | Treinar → **Começar o treino X** → marcar série por série | 2 |
| registrar o pedal que fiz | Treinar → perfil, duração, **Registrar pedal** | 3 |

## Decisões de desenho

**Hoje calcula a próxima ação em vez de listar tudo.** `proximaAcao` no motor ordena por prazo real: janela anabólica aberta (30 min) → refeição da hora → série sugerida → dia fechado. O cartão muda de cor conforme a urgência e leva direto ao lugar de agir.

**Treinar abre NA SÉRIE quando já há treino registrado.** Na academia o que importa é a lista de exercícios com as marcações, não um painel — então o painel some. `telaSessao` passou a ser exportada de `treino.js`, com opções para omitir o botão de voltar e o bloco de volume, em vez de duplicar os cartões de exercício.

**Teto de alertas.** Hoje mostra **um** — o mais urgente. O resto vira `Ver todos os alertas (n)`, que abre uma folha com três grupos: do dia, da janela, atenção contínua. Alerta clínico contínuo (ombro, composição corporal, cirurgião) não é do dia e deixou de ocupar a tela inicial.

**Consultar** agrupa o resto em plano / acompanhamento / registro e dados, e usa `perfil.atalhos` — que tinha ficado órfão — para os links de sub-aba, filtrando os que já aparecem como destino de raiz.

## Resultado medido

No navegador, com o mesmo estado do registro:

| Tela | Antes | Depois |
|---|---|---|
| Hoje | ~10 300 px | **~1 000 px** |

Cabe numa tela e meia em vez de dez.

## Compatibilidade

As 15 rotas antigas continuam funcionando (`#/nutricao/compensacao`, `#/treino/A`, `#/pedal/resistencia`, `#/saude/composicao`…), então links salvos não quebram. Os atalhos do `manifest.json` passaram a apontar para as rotas de operação.

## Verificação

Um teste novo percorre os cinco fluxos ponta a ponta no Chromium — registrar refeição, começar treino, marcar exercícios, registrar pedal, ver o alvo subir — e confere as 15 rotas. As verificações únicas de `fluxo.mjs` (janela anabólica aparecendo e sumindo ao marcar, Nutrição abrindo no tipo de dia derivado, lista de sessões com `próxima`/`✓ feita`) foram absorvidas por ele, e o arquivo antigo foi retirado.

Também passando: os 153 testes do motor, o compositor de refeições, a compensação de gasto, a navegação offline e a fidelidade dos dados.

Service worker em `rotina-v11-2026-07-31`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9VrBnfiWbd7JYxhnejR4W)_