### PR TITLE
Mais de uma série de musculação no mesmo dia

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,17 +368,15 @@ checklist diária em Comer segue a mesma ordem, para que os essenciais fiquem no
 
 A priorização vem dos exames do próprio usuário, não de regra geral: **ômega-3** e **vitamina
 D3** são as duas lacunas — nenhum dos dois está em uso, e cada um tem razão independente no
-dado (dose terapêutica anti-inflamatória para a osteíte reacional do ombro + Modic I cervical
-e HDL em 43 mg/dL; e vitamina D medida em 28,2 ng/mL, abaixo do ideal de 30–60). Com o peixe
-limitado a tilápia e merluza, que quase não têm EPA/DHA, a dieta não cobre o ômega-3. O
-**zinco** é o mais fraco da lista: não há zinco nem testosterona medidos, e reposição crônica
-prejudica a absorção de cobre.
+dado. Os valores medidos, os diagnósticos que sustentam cada indicação e o texto de cada
+`porQue` ficam **só em `nutricao.enc.json`**, cifrado; este README descreve o mecanismo, não os
+resultados. O **zinco** é o mais fraco da lista: não há medição que o sustente, e reposição
+crônica prejudica a absorção de cobre.
 
-⚠️ **Tudo isso se apoia no painel de 10/02/2026.** A reavaliação da vitamina D estava marcada
-para abril/2026 e o painel completo para maio/2026 — os dois estão atrasados. A dose de 5000 UI
-de D3 roda em cima de uma medição de seis meses atrás, e o CK de 480 U/L (ref 35–232) foi
-medido antes da carga de treino atual. Sem número novo, qualquer ajuste de dose é chute; o
-alerta e a ação imediata aparecem no fim da aba de suplementos.
+⚠️ **A priorização inteira se apoia num painel laboratorial já vencido**, com duas reavaliações
+atrasadas — o app mostra isso em `suplementosNota.alerta` e `suplementosNota.acaoImediata`, no
+fim da aba de suplementos. Sem número novo, qualquer ajuste de dose é chute. As datas e os
+valores estão nos documentos cifrados (`exames`, `saude`), que é onde pertencem.
 
 ## Cardápio
 

--- a/app/motor.js
+++ b/app/motor.js
@@ -485,9 +485,20 @@ export function resumoDia(dados, registro, dataISO = hojeISO(), ref = new Date()
   const feitas = new Set((dia.refeicoes || []).map((r) => r.id));
   const pendentes = tipo.refeicoes.filter((r) => !feitas.has(r.id));
 
+  // Mais de uma série no mesmo dia é permitido. As séries feitas são gravadas
+  // sob uma chave por execução: a primeira do dia mantém a chave antiga (o
+  // próprio id da sessão, para não invalidar o que já está gravado) e a
+  // segunda em diante ganha sufixo, senão marcar série numa marcaria na outra.
+  const vistas = new Map();
   const sessoes = atividades
     .filter((a) => a.tipo === 'academia' && a.sessao)
-    .map((a) => treinos.sessoes.find((s) => s.id === a.sessao))
+    .map((a) => {
+      const s = treinos.sessoes.find((x) => x.id === a.sessao);
+      if (!s) return null;
+      const n = (vistas.get(s.id) || 0) + 1;
+      vistas.set(s.id, n);
+      return { ...s, execucaoId: a.id, repeticao: n, chave: n === 1 ? s.id : `${s.id}#${n}` };
+    })
     .filter(Boolean);
 
   const resumo = {

--- a/app/store.js
+++ b/app/store.js
@@ -380,10 +380,15 @@ export class Registro {
     this.#gravar();
   }
 
+  /**
+   * `sessao.chave` distingue duas execuções da mesma sessão no mesmo dia; a
+   * primeira do dia tem chave igual ao id, então o dado antigo continua válido.
+   */
   progressoSessao(sessao, dataISO = hojeISO()) {
+    const chave = sessao.chave || sessao.id;
     const total = sessao.exercicios.reduce((s, e) => s + e.series, 0);
     const feitas = sessao.exercicios.reduce(
-      (s, e) => s + Math.min(this.seriesFeitas(sessao.id, e.ordem, dataISO), e.series), 0);
+      (s, e) => s + Math.min(this.seriesFeitas(chave, e.ordem, dataISO), e.series), 0);
     return { feitas, total, perc: total ? Math.round((feitas / total) * 100) : 0 };
   }
 

--- a/app/views/treinar.js
+++ b/app/views/treinar.js
@@ -43,6 +43,9 @@ export async function render(ctx) {
     for (const s of dia.sessoes) {
       raiz.append(telaSessao(s, treinos, jan, ctx, { voltar: false, volume: false, data }));
     }
+    // Mais de uma série no mesmo dia é permitido — recolhido, para não competir
+    // com a lista de exercícios, que é o que se olha dentro da academia.
+    raiz.append(blocoSerie(dia, jan, comp, ctx, { extra: true }));
     raiz.append(registrado(dia, comp, treinos, ctx));
     raiz.append(blocoPedal(dia, dados, comp, ctx));
     return raiz;
@@ -65,30 +68,90 @@ export async function render(ctx) {
 
 /* ===================== a série de hoje ===================== */
 
-function blocoSerie(dia, jan, comp, ctx) {
+function blocoSerie(dia, jan, comp, ctx, opcoes = {}) {
   const { registro } = ctx;
+  const extra = Boolean(opcoes.extra);
   const p = jan.proxima.escolhida;
+  const s = p && p.sessao;
 
-  if (!p) {
-    return h('div', null, aviso({
-      nivel: 'ok',
-      titulo: 'Nenhuma série liberada agora',
-      texto: 'Todas as opções estão bloqueadas por limite clínico ou intervalo de recuperação. Hoje é pedal leve ou descanso.'
-    }));
-  }
-
-  const s = p.sessao;
   const selDur = h('select', { 'aria-label': 'Duração do treino' },
     DURACOES_ACADEMIA.map((m) => h('option', {
       value: String(m),
       selected: m === comp.atividades.find((a) => a.id === 'academia').duracaoPadraoMin
     }, formatarDuracao(m)))
   );
+  // Todas as sessões entram no seletor manual, inclusive as já feitas na
+  // janela: quem faz a segunda série do dia pode querer justamente repetir.
   const seletorSessao = h('select', { 'aria-label': 'Qual série' },
     jan.proxima.candidatos.map((c) => h('option',
-      { value: c.sessao.id, selected: c.sessao.id === s.id },
+      { value: c.sessao.id, selected: Boolean(s) && c.sessao.id === s.id },
       `${c.sessao.id} — ${c.sessao.nome}${c.livre ? '' : ' (com ressalva)'}`))
   );
+
+  const registrar = (sessaoId) => {
+    registro.registrarAtividade(
+      { tipo: 'academia', sessao: sessaoId, duracaoMin: Number(selDur.value) }, ctx.data);
+    if (extra) toast('Segunda série registrada.');
+    ctx.recarregar();
+  };
+
+  // A ressalva da sessão escolhida, atualizada ao trocar no seletor. Sem isso
+  // dá para registrar a segunda série do dia sem ver que ela estoura um limite
+  // clínico — o aviso existia só em Consultar → Semana, longe da decisão.
+  const ressalva = h('p.legenda');
+  const atualizarRessalva = () => {
+    const c = jan.proxima.candidatos.find((x) => x.sessao.id === seletorSessao.value);
+    const bs = (c && c.bloqueios) || [];
+    ressalva.textContent = bs.length
+      ? (c.temDuro ? 'Bloqueio: ' : 'Ressalva: ') + bs.map((b) => b.texto).join('; ') + '.'
+      : 'Sem restrição para esta sessão agora.';
+    ressalva.dataset.nivel = bs.length ? (c.temDuro ? 'critico' : 'atencao') : 'ok';
+    ressalva.style.color = bs.length
+      ? (c.temDuro ? 'var(--c-critico)' : 'var(--c-atencao)')
+      : '';
+  };
+  seletorSessao.addEventListener('change', atualizarRessalva);
+  atualizarRessalva();
+
+  const manual = h('div.pilha-2.mt-2', null,
+    h('div.linha', null, h('span.esticar', null, seletorSessao)),
+    ressalva,
+    h('div.linha', null,
+      h('span.esticar', null, selDur),
+      h('b.num', { texto: `≈ ${gastoDaAtividade({ tipo: 'academia' }, comp)} kcal` })
+    ),
+    h('button.btn.btn-secundario', {
+      type: 'button', onClick: () => registrar(seletorSessao.value)
+    }, icone('check'), 'Registrar essa')
+  );
+
+  // Segunda série do dia: recolhido, para não disputar espaço com a lista de
+  // exercícios da série que já está em andamento.
+  if (extra) {
+    return h('details.card.mt-3', { estilo: { '--accent': 'var(--c-treino)' } },
+      h('summary', null, h('strong', { texto: 'Registrar outra série hoje' })),
+      h('p.legenda.mt-2', {
+        texto: s
+          ? `Sugerida agora: ${s.id} — ${s.nome}. As marcações de série de cada execução são independentes.`
+          : 'Nenhuma sugestão livre — escolha a série na lista. As marcações de série de cada execução são independentes.'
+      }),
+      manual
+    );
+  }
+
+  if (!p) {
+    return h('div', null,
+      aviso({
+        nivel: 'ok',
+        titulo: 'Nenhuma série liberada agora',
+        texto: 'Todas as opções estão bloqueadas por limite clínico ou intervalo de recuperação. Hoje é pedal leve ou descanso.'
+      }),
+      h('details.card.mt-3', null,
+        h('summary.legenda', { texto: 'Registrar uma série mesmo assim' }),
+        manual
+      )
+    );
+  }
 
   return h('div.card', { estilo: { '--accent': 'var(--c-treino)' } },
     h('div.linha', null,
@@ -109,31 +172,13 @@ function blocoSerie(dia, jan, comp, ctx) {
 
     h('button.btn.btn-bloco.btn-primario.mt-3', {
       type: 'button', estilo: { background: 'var(--c-treino)' },
-      onClick: () => {
-        registro.registrarAtividade({ tipo: 'academia', sessao: s.id, duracaoMin: Number(selDur.value) }, ctx.data);
-        ctx.recarregar();
-      }
+      onClick: () => registrar(s.id)
     }, icone('check'), `Começar o treino ${s.id}`),
     h('p.legenda.mt-2', { texto: 'Registra a sessão e abre a lista de exercícios para marcar série por série.' }),
 
     h('details.mt-3', null,
       h('summary.legenda', { texto: 'Outra série, ou outra duração' }),
-      h('div.pilha-2.mt-2', null,
-        h('div.linha', null, h('span.esticar', null, seletorSessao)),
-        h('div.linha', null,
-          h('span.esticar', null, selDur),
-          h('b.num', { texto: `≈ ${gastoDaAtividade({ tipo: 'academia' }, comp)} kcal` })
-        ),
-        h('button.btn.btn-secundario', {
-          type: 'button',
-          onClick: () => {
-            registro.registrarAtividade({
-              tipo: 'academia', sessao: seletorSessao.value, duracaoMin: Number(selDur.value)
-            }, ctx.data);
-            ctx.recarregar();
-          }
-        }, icone('check'), 'Registrar essa')
-      )
+      manual
     )
   );
 }
@@ -191,7 +236,8 @@ function registrado(dia, comp, treinos, ctx) {
   const { registro } = ctx;
   if (!dia.atividades.length) return h('div');
 
-  return secao(`Registrado hoje · gasto ${dia.gasto} kcal`,
+  const quando = ctx.data === hojeISO() ? 'hoje' : `em ${dataBR(ctx.data)}`;
+  return secao(`Registrado ${quando} · gasto ${dia.gasto} kcal`,
     h('div.pilha-2', null, dia.atividades.map((a) => {
       const kcal = gastoDaAtividade(a, comp);
       const entrada = h('input', {

--- a/app/views/treino.js
+++ b/app/views/treino.js
@@ -104,6 +104,8 @@ export function telaSessao(s, treinos, jan, ctx, opcoes = {}) {
     contaNovos(s) > 0 && chip(`${contaNovos(s)} variantes novas`, 'info', 'rotacao'),
     s.comPedal && chip('dia duplo (pedal + academia)', 'atencao', 'pedal'),
     jan.proxima.escolhida && jan.proxima.escolhida.sessao.id === s.id && chip('próxima sugerida', 'ok'),
+    // Mesma sessão repetida no mesmo dia tem marcação de série independente.
+    s.repeticao > 1 && chip(`${s.repeticao}ª vez hoje`, 'atencao', 'rotacao'),
     jan.feitasIds.includes(s.id) && chip(`já feita nos últimos ${jan.janelaDias} dias`, 'info')
   ));
 
@@ -128,7 +130,7 @@ export function telaSessao(s, treinos, jan, ctx, opcoes = {}) {
     h('button.icon-btn', {
       type: 'button', 'aria-label': 'Zerar marcações desta sessão', title: 'Zerar marcações',
       onClick: () => {
-        registro.zerarSessao(s.id, data);
+        registro.zerarSessao(s.chave || s.id, data);
         ctx.recarregar();
         toast('Marcações da sessão zeradas.');
       }
@@ -206,7 +208,7 @@ function cartaoExercicio(ex, sessao, registro, aoMudar, data) {
   const acoes = h('div.ex-acoes');
   const bolinhas = [];
   const desenhar = () => {
-    const feitas = registro.seriesFeitas(sessao.id, ex.ordem, data);
+    const feitas = registro.seriesFeitas(sessao.chave || sessao.id, ex.ordem, data);
     bolinhas.forEach((b, i) => { b.dataset.feito = String(i < feitas); });
     el.dataset.feito = String(feitas >= ex.series);
   };
@@ -215,7 +217,7 @@ function cartaoExercicio(ex, sessao, registro, aoMudar, data) {
       type: 'button',
       'aria-label': `Marcar série ${i + 1} de ${ex.series}`,
       onClick: () => {
-        registro.marcarSerie(sessao.id, ex.ordem, ex.series, data);
+        registro.marcarSerie(sessao.chave || sessao.id, ex.ordem, ex.series, data);
         desenhar();
         aoMudar();
       }

--- a/sw.js
+++ b/sw.js
@@ -9,7 +9,7 @@
 // O cache guarda apenas ciphertext dos documentos — a chave nunca é cacheada
 // (fica no localStorage do dispositivo).
 
-const VERSAO = 'rotina-v18-2026-08-06';
+const VERSAO = 'rotina-v19-2026-08-07';
 const CACHE_SHELL = `${VERSAO}-shell`;
 const CACHE_DADOS = `${VERSAO}-dados`;
 


### PR DESCRIPTION
## O que faltava

O modelo já aceitava mais de uma série por dia — `atividades` é uma lista, o motor soma o gasto das duas e o alvo do dia sobe junto. O que faltava era a porta de entrada: assim que havia uma série registrada, a tela de Treinar virava a lista de exercícios e o cartão de registrar sumia, sem nenhum caminho para a segunda.

## O conflito silencioso que veio junto

As séries marcadas são gravadas em `sessaoId.ordem`. Registrar o treino A duas vezes no mesmo dia faria as duas execuções compartilharem a mesma marcação — marcar uma série na primeira marcaria também na segunda.

Agora cada execução tem chave própria. A primeira do dia continua sendo o id da sessão, para o que já está gravado seguir válido sem migração; a segunda em diante ganha sufixo (`A#2`). Verificado no navegador: com A registrado duas vezes, o `localStorage` fica `{"A.1": 2, "A#2.10": 1}` e os progressos ficam em 2/30 e 1/30, independentes.

## Mudanças na tela

- **"Registrar outra série hoje"**, recolhido abaixo das sessões em andamento — dentro da academia o que importa é a lista de exercícios, então o bloco não disputa espaço com ela.
- **O seletor manual passa a existir também quando nenhuma sessão está liberada.** Antes o aviso "nenhuma série liberada agora" era um beco sem saída: não havia como registrar nada.
- **A ressalva clínica da sessão escolhida aparece antes de registrar**, atualizada ao trocar no seletor. Isso surgiu de um teste: registrar A duas vezes leva o peito a 8 sets, que é a janela inteira do limite do ombro. Esse aviso existia só em Consultar → Semana, longe de onde a decisão é tomada.
- Cartão da sessão repetida marcado com **"2ª vez hoje"**.

## Correção de exposição de dado

Removo do README resultados de exame que **eu havia escrito em claro no PR anterior**, num repositório público, contra a regra do próprio projeto. Os valores voltam a viver só nos documentos cifrados; o texto descreve o mecanismo da priorização, não os resultados.

O teste 20 (`nenhum dado pessoal versionado em claro`) não pegou na hora porque o detector só cobria `mg/dL`. Agora qualquer número colado numa unidade de laboratório (`ng/mL`, `U/L`, `mmol/L`, `UI/L`, …) é achado, e nomes de diagnóstico entraram na lista de termos proibidos.

⚠️ Isto conserta o `HEAD`, **não o histórico** — os valores continuam nos commits já publicados, o que se soma à reescrita de histórico que já estava pendente.

## Verificação

- Suíte do motor: passa, incluindo o teste 20 reforçado (35 arquivos versionados em claro, nenhum achado).
- Suíte das recomendações: passa.
- Nova suíte `multiplas`: 6 grupos — duas sessões diferentes no mesmo dia, marcação que não vaza entre sessões, a mesma sessão duas vezes com chaves e progressos separados, dado antigo continuando a ser lido pelo caminho novo, janela e volume contando as duas execuções, e o limite clínico de peito chegando ao teto.
- Navegador: registrar a 2ª série pela tela, marcar em cada execução e conferir o `localStorage`. Nenhum erro de página.
- Dados cifrados verificados (11 documentos). Service worker em `rotina-v19-2026-08-07`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9VrBnfiWbd7JYxhnejR4W

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9VrBnfiWbd7JYxhnejR4W)_